### PR TITLE
added colon to quickstart script so it works

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,8 +9,8 @@ searchTitle: Eleventy Home
 ## Quick Start
 
 ``` bash
-npm install -g @11ty/eleventy
-echo '# Page header' > README.md
+npm install -g @11ty/eleventy;
+echo '# Page header' > README.md;
 eleventy
 ```
 


### PR DESCRIPTION
The quickstart bash instruction fails because there is no semi colon to seperate the commands.
Until a new line is added to the markdown output, this is the best solution.