### PR TITLE
Add youtube-embed plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -32,6 +32,7 @@ All official plugins live under the `@11ty` npm organization and plugin names wi
 * [eleventy-xml-plugin](https://www.npmjs.com/package/eleventy-xml-plugin) by [Jeremias Menichelli](https://jeremenichelli.io) adds Liquid filters used for sitemap and RSS/feed file generation.
 * [eleventy-plugin-markdown-shortcode](https://www.npmjs.com/package/eleventy-plugin-markdown-shortcode) by [Tyler Williams](https://ogdenstudios.xyz) adds a universal shortcode to render markdown. 
 * [eleventy-plugin-sass](https://www.npmjs.com/package/eleventy-plugin-sass) by [Maarten Schroeven](https://github.com/Sonaryr) will add the ability to use Sass for your stylesheets
+* [eleventy-plugin-youtube-embed](https://www.npmjs.com/package/eleventy-plugin-youtube-embed) by [Graham F. Scott](https://twitter.com/gfscott) automatically embeds YouTube videos based on just their URLs.
 * [**Search for `eleventy-plugin` on `npm`**](https://www.npmjs.com/search?q=eleventy-plugin)
 
 


### PR DESCRIPTION
I made a little [plugin](https://www.npmjs.com/package/eleventy-plugin-youtube-embed) that uses a transform to turn Youtube URLs on their own line into embeds. Just hoping to add it to the list!