### PR TITLE
Fix link to community article

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -452,6 +452,6 @@ module.exports = function(eleventyConfig) {
 <div class="elv-community" id="community-resources">
   <h3 class="elv-community-hed">Community Resources</h3>
   <ul>
-    <li><a href="https://www.pborenstein.com/articles/collections/">Working with Collections</a> by {% avatarlocalcache "twitter", "pborenstein" %}Philip Borenstein</li>
+    <li><a href="https://www.pborenstein.com/posts/collections/">Working with Collections</a> by {% avatarlocalcache "twitter", "pborenstein" %}Philip Borenstein</li>
   </ul>
 </div>


### PR DESCRIPTION
The link to Philip Borestein's article under community resources was broken. This update fixes the URL.