### PR TITLE
fix missing page- permalink prefix

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -246,7 +246,7 @@ You can even use template logic here too:
 {% raw %}
 ```markdown
 ---
-permalink: "different/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber + 1 }}/{% endif %}index.html"
+permalink: "different/{% if pagination.pageNumber > 0 %}page-{{ pagination.pageNumber + 1 }}/{% endif %}index.html"
 ---
 ```
 {% endraw %}


### PR DESCRIPTION
[Remapping with Permalinks](https://www.11ty.dev/docs/pagination/#remapping-with-permalinks) code example was missing the `page-` prefix, which resulted in `_site/different/index.html`, `_site/different/2/index.html`, et cetera.

This PR will result in `_site/different/index.html`, `_site/different/page-2/index.html`, et cetera, as intended by the docs.