### PR TITLE
Remove extra span tags

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -223,7 +223,7 @@ ${text.trim()}
 	});
 
 	eleventyConfig.addShortcode("testimonial", function(testimonial) {
-		return `<blockquote><p>${!testimonial.indirect ? `“` : ``}${testimonial.text}${!testimonial.indirect ? `” <span class="bio-source">—${shortcodes.link(testimonial.source, shortcodes.avatarlocalcache("twitter", testimonial.twitter, `${testimonial.name}’s Twitter Photo`) + testimonial.name)}` : ``}</span></p></blockquote>`;
+		return `<blockquote><p>${!testimonial.indirect ? `“` : ``}${testimonial.text}${!testimonial.indirect ? `” <span class="bio-source">—${shortcodes.link(testimonial.source, shortcodes.avatarlocalcache("twitter", testimonial.twitter, `${testimonial.name}’s Twitter Photo`) + testimonial.name)}</span>` : ``}</p></blockquote>`;
 	});
 
 	eleventyConfig.addShortcode("supporterAmount", function(amount, maxAmount = 1000) {

--- a/docs/search.md
+++ b/docs/search.md
@@ -16,7 +16,7 @@ putTheJsInTheHead: true
 	</div>
 	<p>Search provided by <span data-investors-avatar="prepend"><span data-investors-toggle="you—thank you for supporting Eleventy!"></span></span><span class="investors-noauth"><a href="https://duckduckgo.com/">Duck Duck Go</a>.</span></p>
 	<p class="investors-noauth">As a special thank you, <a href="/docs/account/">Eleventy Contributor Accounts</a> are provided access to an enhanced on-site documentation search. If you would like access to this feature too, <a href="https://opencollective.com/11ty">donate to Eleventy on Open Collective!</a></p>
-	<p class="investors-noauth">Already a contributor? <a href="/docs/account/">Log in!</a></span></p>
+	<p class="investors-noauth">Already a contributor? <a href="/docs/account/">Log in!</a></p>
 </form>
 <div id="search-results" class="hide">
 	<h2 id="search-results-count" aria-live="polite">Results</h2>


### PR DESCRIPTION
Fixes a handful of HTML markup errors being reported by <kbd>npx prettier '_site/**/*.html' --write</kbd>.

Several errors still remain, but they all seem to be related to the table-of-contents issue below; where the page has a `[[toc]]` placeholder in the markdown, which is getting wrapped in a `<p>` tag (because markdown), and then then embeds a `<div>` tag, giving us invalid markup like `<p><div>...</div></p>`.


```
[error] _site/docs/plugins/navigation/index.html: SyntaxError: Unexpected closing tag "p". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (2343:898)
[error]   2341 | </ul>
[error]   2342 | <h2 id="contents">Contents <a class="direct-link" href="#contents">#</a></h2>
[error] > 2343 | <p><div class="table-of-contents"><ul><li><a href="#contents">Contents</a></li><li><a href="#template-compatibility">Template Compatibility</a></li><li><a href="#installation">Installation</a></li><li><a href="#adding-templates-to-the-navigation">Adding Templates to the Navigation</a><ul><li><a href="#example">Example</a></li><li><a href="#use-alternate-text-for-the-navigation-link">Use alternate text for the navigation link</a></li><li><a href="#re-ordering-items">Re-Ordering Items</a></li><li><a href="#overriding-the-url">Overriding the URL</a></li></ul></li><li><a href="#rendering-the-navigation-bar-(nunjucks-only)">Rendering the Navigation Bar (Nunjucks-only)</a><ul><li><a href="#just-give-me-some-code">Just Give Me Some Code</a></li><li><a href="#fetch-the-structure">Fetch the Structure</a></li><li><a href="#render-the-structure">Render the Structure</a></li></ul></li></ul></div></p>
[error]        |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ^
[error]   2344 | <h2 id="template-compatibility">Template Compatibility <a class="direct-link" href="#template-compatibility">#</a></h2>
[error]   2345 | <ul>
[error]   2346 | <li>Any template language can add to navigation.</li>
```
