### PR TITLE
Update pagination.md

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -183,7 +183,7 @@ This resolves to:
 
 ```js
 {
-  myData: [
+  "myData": [
     "item1",
     "item2",
     "item3",


### PR DESCRIPTION
https://github.com/11ty/eleventy/issues/690#issuecomment-592266524

This example without these added quotes throws `TemplateDataParseError` when testing it out on a clean and fresh install.

Copy and paste jockys will no doubt encounter this and probably already do. I did.