### PR TITLE
add blog.progressionapp.com

### DIFF
--- a/_data/sites/blogprogressionapp.json
+++ b/_data/sites/blogprogressionapp.json
@@ -1,0 +1,6 @@
+{
+	"url": "https://www.progressionapp.com/blog/",
+	"name": "Progression blog",
+	"description": "The blog for Progression, a product to help teams support personal development and career growth",
+	"twitter": "progressionapp"
+}


### PR DESCRIPTION
blog.progressionapp.com does not work anymore. The domain gets redirected to progressionapp.com/blog

fixes #192