### PR TITLE
rss.md: --save instead of --save-dev

### DIFF
--- a/docs/plugins/rss.md
+++ b/docs/plugins/rss.md
@@ -19,7 +19,7 @@ A pack of plugins for generating an RSS feed (actually an Atom feed, but who’s
 Available on [npm](https://www.npmjs.com/package/@11ty/eleventy-plugin-rss).
 
 ```
-npm install @11ty/eleventy-plugin-rss --save-dev
+npm install @11ty/eleventy-plugin-rss --save
 ```
 
 Open up your Eleventy config file (probably `.eleventy.js`) and use `addPlugin`:


### PR DESCRIPTION
With --save-dev, it will work in development and break on deployment to e.g. Netlify.

I've seen this in the instructions for other plugins as well, but thought I'd start with this tiny PR. If you agree, I'm happy to make more.