### PR TITLE
Add dark color scheme styles

### DIFF
--- a/_includes/components/callout.css
+++ b/_includes/components/callout.css
@@ -7,6 +7,15 @@
 	margin-bottom: 2em;
 	background-color: #dff7ff;
 }
+@media (prefers-color-scheme: dark) {
+  .elv-callout {
+	  background-color: #00bcd4;
+  }
+  .elv-callout,
+  .elv-callout a {
+    color: #222;
+  }
+}
 table .elv-callout {
 	margin-left: 0;
 	margin-right: 0;
@@ -21,6 +30,11 @@ table .elv-callout {
 }
 .elv-callout-warn {
 	background-color: #ffa;
+}
+@media (prefers-color-scheme: dark) {
+  .elv-callout-warn {
+	  background-color: #ffff34;
+  }
 }
 .elv-callout-warn:before {
 	content: "⚠️ ";

--- a/_includes/components/code.css
+++ b/_includes/components/code.css
@@ -62,6 +62,17 @@ pre + .note {
 	margin-bottom: 2.5em; /* 40px /16 */
 	text-align: right;
 }
+@media (prefers-color-scheme: dark) {
+  pre {
+    border: 2px solid #bbb;
+  }
+  code {
+    color: #222;
+  }
+  pre code {
+    color: unset;
+  }
+}
 @media (min-width: 37.5em) { /* 600px */
 	pre {
 		font-size: 1em; /* 16px /16 */

--- a/_includes/components/codetitle.css
+++ b/_includes/components/codetitle.css
@@ -7,6 +7,11 @@
 	font-size: 0.75em; /* 12px /16 */
 	background-color: #fff;
 }
+@media (prefers-color-scheme: dark) {
+  .codetitle {
+    color: #222;
+  }
+}
 .codetitle-left {
 	float: left;
 	clear: left;

--- a/_includes/components/community.css
+++ b/_includes/components/community.css
@@ -5,6 +5,12 @@
 	margin-left: -1rem;
 	margin-right: -1rem;
 }
+@media (prefers-color-scheme: dark) {
+  .elv-community,
+  .elv-community a {
+    color: #222;
+  }
+}
 .elv-community-hed {
 	margin-top: 0;
 }

--- a/_includes/components/lists.css
+++ b/_includes/components/lists.css
@@ -63,6 +63,11 @@
 		top: -2px;
 		bottom: 2px;
 	}
+  @media (prefers-color-scheme: dark) {
+    .inlinelist .inlinelist-item code:before {
+      border-left-color: rgba(0,0,0,.8);
+    }
+  }
 }
 a.buzzword {
 	text-decoration: underline;
@@ -86,8 +91,22 @@ a.buzzword {
 .buzzword {
 	background-color: #f7f7f7;
 }
+@media (prefers-color-scheme: dark) {
+  .buzzword-list li,
+  .buzzword {
+    background-color: #080808;
+  }
+}
 .inlinelist .inlinelist-item {
 	background-color: #e9e9e9;
+}
+@media (prefers-color-scheme: dark) {
+  .inlinelist .inlinelist-item a {
+    color: #161616;
+  }
+  .inlinelist .inlinelist-item code {
+    color: inherit;
+  }
 }
 .inlinelist .inlinelist-item:hover,
 .inlinelist .inlinelist-item:focus,
@@ -194,6 +213,12 @@ main p a.buzzword {
 	width: 1.75em;
 	height: 1.75em;
 	font-weight: 600;
+}
+@media (prefers-color-scheme: dark) {
+  .numberflag {
+    background-color: #00bcd4;
+    color: #222;
+  }
 }
 h1 .numberflag,
 h2 .numberflag,

--- a/_includes/components/minilink.css
+++ b/_includes/components/minilink.css
@@ -12,6 +12,16 @@
 	line-height: 1.285714285714; /* 18px /14 */
 	font-family: system-ui, -apple-system, sans-serif;
 }
+@media (prefers-color-scheme: dark) {
+  .minilink {
+    background-color: #222;
+    /*
+      !important to override .elv-callout a
+      see _includes/components/callout.css
+     */
+    color: #fff !important;
+  }
+}
 table .minilink {
 	margin-top: 6px;
 }
@@ -21,6 +31,12 @@ table .minilink {
 .minilink[href]:hover,
 .minilink[href]:focus {
 	background-color: #bbb;
+}
+@media (prefers-color-scheme: dark) {
+  .minilink[href]:hover,
+  .minilink[href]:focus {
+    background-color: #444;
+  }
 }
 pre + .minilink {
 	color: #fff;
@@ -57,6 +73,11 @@ h4 .minilink {
 .minilink-addedin {
 	text-transform: none;
 	box-shadow: 0 0 0 1px rgba(0,0,0,0.3);
+}
+@media (prefers-color-scheme: dark) {
+  .minilink-addedin {
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.3);
+  }
 }
 .minilink-addedin:not(:first-child) {
 	margin-left: .5em;

--- a/_includes/components/page-supporters.css
+++ b/_includes/components/page-supporters.css
@@ -49,6 +49,11 @@
 	opacity: .4;
 	font-size: 0.875em; /* 14px /16 */
 }
+@media (prefers-color-scheme: dark) {
+  .supporters-hearts-empty {
+    filter: grayscale(0.5) brightness(100%);
+  }
+}
 .supporters-facepile .avatar {
 	margin-bottom: 0;
 }

--- a/_includes/components/toc.css
+++ b/_includes/components/toc.css
@@ -78,10 +78,21 @@
 	border-bottom: 1px solid #ddd;
 	margin-bottom: 0.25em; /* 4px /16 */
 }
+@media (prefers-color-scheme: dark) {
+  .elv-toc-list > li > a {
+    color: #fff;
+  }
+}
 
 /* Active links */
 .elv-toc-list li.elv-toc-active > a {
 	background-color: #dff7ff;
+}
+@media (prefers-color-scheme: dark) {
+  .elv-toc-list li.elv-toc-active > a {
+    background-color: #00bcd4;
+    color: #222;
+  }
 }
 .elv-toc-list ul .elv-toc-active > a:after {
 	content: "";

--- a/_includes/index.css
+++ b/_includes/index.css
@@ -2,7 +2,7 @@
 .sr-only {
 	position: absolute;
 	height: 1px;
-	width: 1px; 
+	width: 1px;
 	overflow: hidden;
 	clip: rect(1px, 1px, 1px, 1px);
 }
@@ -21,6 +21,12 @@ body {
 	color: #222;
 	margin: 0;
 }
+@media (prefers-color-scheme: dark) {
+  body {
+   background-color: #222;
+   color: #fff;
+  }
+}
 .elv-docs body {
 	max-width: 76em;
 	margin: 0 auto;
@@ -32,6 +38,18 @@ a,
 a:visited,
 a[href] {
 	color: #222;
+}
+@media (prefers-color-scheme: dark) {
+  a,
+  a:visited,
+  a[href] {
+    color: #fff;
+  }
+  .btn-primary,
+  a.btn-primary {
+    border-color: #fff;
+    color: #222;
+  }
 }
 a[href].naked {
 	text-decoration: none;
@@ -76,10 +94,14 @@ blockquote {
 	max-width: 31.57894736842em; /* 600px /19 */
 	border-left: 6px solid #ddd;
 }
+@media (prefers-color-scheme: dark) {
+  blockquote {
+    color: #bbb;
+  }
+}
 blockquote + blockquote {
 	margin-top: 2em;
 }
-
 .icon,
 .has-svg-icon > svg,
 .avatar,
@@ -111,7 +133,11 @@ ul:not(.list-bare):not(.inlinelist) > li > a > .avatar {
 blockquote .bio-source {
 	white-space: nowrap;
 }
-
+@media (prefers-color-scheme: dark) {
+  .has-svg-icon > svg {
+    fill: #fff;
+  }
+}
 /* Main */
 main {
 	font-size: 1.125em; /* 18px /16 */
@@ -260,6 +286,11 @@ li li {
 	color: #555;
 	margin-bottom: 3px;
 }
+@media (prefers-color-scheme: dark) {
+  .list-bare-desc {
+    color: #bbb;
+  }
+}
 .list-bare-desc:last-child {
 	margin-bottom: 6px;
 }
@@ -342,6 +373,11 @@ footer.elv-layout {
 	width: calc(100% + 2rem);
 	margin-left: -1rem;
 	margin-right: -1rem;
+}
+@media (prefers-color-scheme: dark) {
+  .elv-header-default .elv-hero {
+    border-bottom: 1px solid #fff;
+  }
 }
 .elv-header-docs .elv-hero {
 	float: left;
@@ -508,6 +544,11 @@ main .elv-toc + h1 .direct-link {
 	background-color: #f7f7f7;
 	padding: .5rem;
 	margin: 2em 0;
+}
+@media (prefers-color-scheme: dark) {
+  .elv-langlist {
+    background-color: #080808;
+  }
 }
 .elv-langlist-hed {
 	margin: 0;


### PR DESCRIPTION
@zachleat,

In service to accessibility and flexibility, I thought it’d be nice for the docs to have a dark color scheme option, based on the user’s system preferences. (It would also help me immensely in my late night coding work after my 2yo son goes to sleep in our one-bedroom condo.)

To keep things simple, I put the `@media` queries immediately after the rule to override from the default light theme. The only exception to this pattern is in [`_includes/components/code.css`](https://github.com/11ty/11ty-website/compare/master...reubenlillie:reubenlillie-dark-color-scheme?expand=1#diff-f031f10f96935eab4c8b9fd6dad5e6b0), where I had to create new rules to ensure that `pre` and `code` blocks worked in their different combinations. There’s certainly room for future optimization, but I figured it’d be better for tracking individual changes in the meantime.

And, to keep color choices consistent, I held to the following rules of thumb (in order of precedence)

1. The exact opposite color value of the one being overridden (e.g., from very dark to very light);
1. A darker tint (e.g., warning callouts); or
1. A similar color value already used elsewhere in the site when a darker tint was otherwise too similar to warrant using different color codes (e.g., informational callouts and TOC list items using the same color as underlined hyperlinks).

The only exceptions to these rules were

1. `#fff` for body text (instead of `#ddd`), because it swaps the background and foreground values from the light theme; and
1. `#bbb` instead of `#aaa` against `#222`, because the former meets the WCAG AAA standard at a contrast ratio of 8.29:1, whereas the latter only meets AA at contrast ratio of 6.85:1 (which, in this case, is particularly important for uses in brighter surrounding trying to a dark color scheme); and
1. The `filter` on the `.supporters-hearts-empty` emoji—to make sure they were still visible against the dark background.

PS, I’m not sure what’s going in with the removal and addition of the `}` that came along for the ride in each of the committed files. I think it might be from how I trim trailing whites pace automatically on save in my Vim settings 🤷‍♂️.