### PR TITLE
Adds eleventy-blog-mnml to 11ty starters

### DIFF
--- a/_data/starters.json
+++ b/_data/starters.json
@@ -118,5 +118,11 @@
 		"name": "11ty-encore",
 		"description": "11ty using webpack encore",
 		"author": "disjfa"
+	},
+	{
+		"url": "https://github.com/arpitbatra123/eleventy-blog-mnml",
+		"name": "eleventy-blog-mnml",
+		"description": "A minimal blog template using eleventy",
+		"author": "arpitbatra123"
 	}
 ]


### PR DESCRIPTION
This PR adds my project `eleventy-blog-mnml` to the list of 11ty starters.