### PR TITLE
Add JavaScript examples for collections

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -40,10 +40,10 @@ This will place this `mypost.md` into the `post` collection with all other piece
 
 {% raw %}
 ```js
-module.exports = function({collections}) {
+exports.render = function(data) {
   return `<ul>
-${collections.post.map((post) => `<li>${ post.data.title }</li>`).join("\n")}
-</ul>`;
+    ${data.collections.post.map(post => `<li>${post.data.title}</li>`).join("\n")}
+  </ul>`;
 };
 ```
 {% endraw %}
@@ -64,11 +64,27 @@ Compare the `post.url` and special Eleventy-provided `page.url` variable to find
 ```
 {% endraw %}
 
+{% codetitle "JavaScript .11ty.js", "Syntax" %}
+
+{% raw %}
+```js
+exports.render = function(data) {
+  return `<ul>
+    ${data.collections.post.map(post =>
+      `<li${data.page.url === post.url ? `class="active"` : ""}>${post.data.title}</li>`
+    ).join("\n");}
+  </ul>`;
+};
+```
+{% endraw %}
+
 ## The Special `all` Collection
 
 By default Eleventy puts all of your content (independent of whether or not it has any assigned tags) into the `collections.all` Collection. This allows you to iterate over all of your content inside of a template.
 
 ### Example: A list of links to all Eleventy generated content
+
+{% codetitle "Liquid,Nunjucks", "Syntax" %}
 
 {% raw %}
 ```html
@@ -77,6 +93,20 @@ By default Eleventy puts all of your content (independent of whether or not it h
   <li><a href="{{ post.url }}">{{ post.url }}</a></li>
 {%- endfor -%}
 </ul>
+```
+{% endraw %}
+
+{% codetitle "JavaScript .11ty.js", "Syntax" %}
+
+{% raw %}
+```js
+exports.render = function(data) {
+  return `<ul>
+    ${data.collections.post.map(post =>
+      `<li><a href="${post.url}">${post.url}</a></li>`
+    ).join("\n");}
+  </ul>`;
+};
 ```
 {% endraw %}
 
@@ -141,6 +171,18 @@ This content would show up in the template data inside of `collections.cat` and 
   <li>{{ post.data.title }}</li>
 {%- endfor -%}
 </ul>
+```
+{% endraw %}
+
+{% codetitle "JavaScript .11ty.js", "Syntax" %}
+
+{% raw %}
+```js
+exports.render = function(data) {
+  return `<ul>
+    ${data.collections.post.map(post => `<li>${post.data.title}</li>`).join("\n");}
+  </ul>`;
+};
 ```
 {% endraw %}
 
@@ -219,6 +261,20 @@ And in Liquid it’d look like this:
 ```
 {% endraw %}
 
+And in JavaScript it’d look like this:
+
+{% codetitle "JavaScript .11ty.js", "Syntax" %}
+
+{% raw %}
+```js
+exports.render = function(data) {
+  let posts = data.collections.post.reverse();
+  return `<ul>
+    ${posts.map(post => `<li>${post.data.title}</li>`).join("\n");}
+  </ul>`;
+};
+```
+{% endraw %}
 
 <div class="elv-callout elv-callout-warn elv-callout-warn-block" id="array-reverse">
   <p>You should <em><strong>not</strong></em> use Array <code>reverse()</code> on collection arrays in your templates, like so:</p>
@@ -249,7 +305,7 @@ Inside of your `.eleventy.js` config file, use the first argument to the config 
 ```js
 module.exports = function(eleventyConfig) {
   // API is available in `eleventyConfig` argument
-  
+
   return {
     // your normal config options
     markdownTemplateEngine: "njk"

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -36,36 +36,6 @@ testdata:
 ```
 {% endraw %}
 
-Or this one in JavaScript, in case you prefer another [templating language](/docs/languages/):
-
-{% codetitle "JavaScript", "Syntax" %}
-
-{% raw %}
-```js
-exports.data = {
-  pagination: {
-    data: "testdata",
-    size: 2
-  },
-  testdata: [
-    "item1",
-    "item2",
-    "item3",
-    "item4"
-  ]
-};
-
-exports.render = function(data) {
-  return `<ol>
-    ${data.pagination.items.map(function(item) {
-        return `<li>${item}</li>`;
-      }).join("");
-    }
-  </ol>`;
-};
-```
-{% endraw %}
-
 We enable pagination and then give it a dataset with the `data` key. We control the number of items in each chunk with `size`. The pagination data variable will be populated with what you need to create each template. Here’s what’s in `pagination`:
 
 {% codetitle "JavaScript Object", "Syntax" %}

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -36,6 +36,36 @@ testdata:
 ```
 {% endraw %}
 
+Or this one in JavaScript, in case you prefer another [templating language](/languages/):
+
+{% codetitle "JavaScript", "Syntax" %}
+
+{% raw %}
+```js
+exports.data = {
+  pagination: {
+    data: "testdata",
+    size: 2
+  },
+  testdata: [
+    "item1",
+    "item2",
+    "item3",
+    "item4"
+  ]
+};
+
+exports.render = function(data) {
+  return `<ol>
+    ${data.pagination.items.map(function(item) {
+        return `<li>${item}</li>`;
+      }).join('');
+    }
+  </ol>`;
+};
+```
+{% endraw %}
+
 We enable pagination and then give it a dataset with the `data` key. We control the number of items in each chunk with `size`. The pagination data variable will be populated with what you need to create each template. Here’s what’s in `pagination`:
 
 {% codetitle "JavaScript Object", "Syntax" %}

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -36,7 +36,7 @@ testdata:
 ```
 {% endraw %}
 
-Or this one in JavaScript, in case you prefer another [templating language](/languages/):
+Or this one in JavaScript, in case you prefer another [templating language](/docs/languages/):
 
 {% codetitle "JavaScript", "Syntax" %}
 
@@ -59,7 +59,7 @@ exports.render = function(data) {
   return `<ol>
     ${data.pagination.items.map(function(item) {
         return `<li>${item}</li>`;
-      }).join('');
+      }).join("");
     }
   </ol>`;
 };


### PR DESCRIPTION
I strayed from [my comment about arrow functions](https://github.com/11ty/11ty-website/issues/397#issuecomment-602605912) in #397 here for space, and since the one example on the page had already been using an arrow function (which I also updated a wee bit for consistency with the other examples).