### PR TITLE
Suggestion: Live refresh 404 pages on change

### DIFF
--- a/docs/quicktips/not-found.md
+++ b/docs/quicktips/not-found.md
@@ -55,9 +55,9 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.setBrowserSyncConfig({
     callbacks: {
       ready: function(err, bs) {
-        const content_404 = fs.readFileSync('_site/404.html');
 
         bs.addMiddleware("*", (req, res) => {
+          const content_404 = fs.readFileSync('_site/404.html');
           // Provides the 404 content without redirect.
           res.write(content_404);
           // Add 404 http status code in request header.


### PR DESCRIPTION
When using `eleventy --serve` and the current documentation, you have to cancel the session and start again to see new changes to the 404 page.

I would like to suggest the documentation to be updated to move `fs.readFileSync('_site/404.html');` into the `addMiddleware` function. This allows the 404 page to live refresh as changes are made to a markdown file. The downsides of this are that on every time browser-sync is ran on a 404 route it will read the `'_site/404.html'` file and update what is sent back to the user.

I am not sure if this was considered before and not done as a slight performance boost. Let me know what you think?

@clottman you might also have context on this?

---

Here is an [example repository](https://github.com/alex-page/site-template) with the change. You can see the 404 page refreshing as changes are made to `/src/404.md`.

https://github.com/alex-page/site-template/blob/aca3493a898a447cc18acdc7e135a82bb64881b6/.eleventy.js#L51-L59