### PR TITLE
Add warnings about Content Security Policy to inline quick tips

### DIFF
--- a/docs/quicktips/concatenate.md
+++ b/docs/quicktips/concatenate.md
@@ -46,3 +46,9 @@ In our [Inline CSS Quick Tip](/docs/quicktips/inline-css/), we discussed how to 
 Of course, Eleventy has no desire to replace your existing build pipeline. This is just a super simple example if you want something up and running quickly.
 
 That said, Eleventy wants to work with what you have. As an example, the [`EleventyOne` project scaffold](https://github.com/philhawksworth/eleventyone/) is a fine example of using Eleventy with Gulp and Sass. The [zachleat.com source code](https://github.com/zachleat/zachleat.com) is an older example that works with Grunt and Sass.
+
+### Warning about Content Security Policy
+
+{% callout "warn" %}
+If you are using a Content Security Policy on your website, make sure the <code>style-src</code> directive allows <code>'unsafe-inline'</code>. Otherwise, your inline CSS will not load.
+{% endcallout %}

--- a/docs/quicktips/inline-css.md
+++ b/docs/quicktips/inline-css.md
@@ -53,3 +53,9 @@ Capture the CSS into a variable and run it through the filter (this sample is us
 </style>
 ```
 {% endraw %}
+
+### Warning about Content Security Policy
+
+{% callout "warn" %}
+If you are using a Content Security Policy on your website, make sure the <code>style-src</code> directive allows <code>'unsafe-inline'</code>. Otherwise, your inline CSS will not load.
+{% endcallout %}

--- a/docs/quicktips/inline-js.md
+++ b/docs/quicktips/inline-js.md
@@ -56,3 +56,9 @@ Capture the JavaScript into a variable and run it through the filter (this sampl
 </script>
 ```
 {% endraw %}
+
+### Warning about Content Security Policy
+
+{% callout "warn" %}
+If you are using a Content Security Policy on your website, make sure the <code>script-src</code> directive allows <code>'unsafe-inline'</code>. Otherwise, your inline Javascript will not load.
+{% endcallout %}


### PR DESCRIPTION
I have added reminders to the quick tips to think about Content Security Policy on the inline CSS and inline JS quick tips. This PR says to add the 'unsafe-inline' sources to the style-src and script-src if you want to use these approaches.