### PR TITLE
remove redundant code re: markdown-it-anchor

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -301,15 +301,6 @@ ${text.trim()}
 		return DateTime.fromJSDate(dateObj).toFormat("yyyy LLLL dd");
 	});
 
-	// Until https://github.com/valeriangalliat/markdown-it-anchor/issues/58 is fixed
-	eleventyConfig.addTransform("remove-aria-hidden-markdown-anchor", function(content, outputPath) {
-		if( outputPath && outputPath.endsWith(".html") ) {
-			return content.replace(/ aria\-hidden\=\"true\"\>\#\<\/a\>/g, ` title="Direct link to this heading">#</a>`);
-		}
-
-		return content;
-	});
-
 	eleventyConfig.addFilter("calc", (sites, type, key) => {
 		let sum = 0;
 		let values = [];


### PR DESCRIPTION
Issue 58 in Markdown-it-anchor is closed as it was resolved in 5.2.5

According to your package.json, markdown-it-anchor is requiring 5.2.5, therefore this code is redundant