### PR TITLE
Improve sort order Liquid example

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -211,8 +211,7 @@ And in Liquid it’d look like this:
 {% raw %}
 ```html
 <ul>
-{%- assign posts = collections.post | reverse -%}
-{%- for post in posts -%}
+{%- for post in collections.post reversed -%}
   <li>{{ post.data.title }}</li>
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
The Liquid `for` tag has a built-in parameter for reversing direction. This removes the need for assigning the reversed collection to a separate variable.

Source: http://shopify.github.io/liquid/tags/iteration/#reversed