### PR TITLE
Add reference to ignore options for addWatchTarget

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -523,6 +523,8 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
+Eleventy will not add a watch for files or folders that are in `.gitignore`, unless `setUseGitIgnore` is turned off. See the chapter on [ignore files](/docs/ignores/#opt-out-of-using-.gitignore).
+
 ### Override Browsersync Server Options {% addedin "0.7.0" %}
 
 Useful if you want to change or override the default Browsersync configuration. Find the Eleventy defaults in [`EleventyServe.js`](https://github.com/11ty/eleventy/blob/master/src/EleventyServe.js). Take special note that Eleventy does not use Browsersync’s watch options and trigger reloads manually after our own internal watch methods are complete. See full options list on the [Browsersync documentation](https://browsersync.io/docs/options).


### PR DESCRIPTION
A change proposed to solve https://github.com/11ty/11ty-website/issues/464
See also https://github.com/11ty/eleventy/issues/893

Eleventy normally ignores files in `.gitignore`, and this also applies to `addWatchTarget`. A related option – not mentioned in the `addWatchTarget` documentation – allows to revert this behaviour.

This patch adds an explanation and link in the relevant doc page.