### PR TITLE
Add a fileSlug example with date-only inputPath

### DIFF
--- a/docs/data-eleventy-supplied.md
+++ b/docs/data-eleventy-supplied.md
@@ -53,6 +53,7 @@ The `fileSlug` variable is mapped from inputPath and is useful for creating your
 
 | `inputPath` | `page.fileSlug` Result |
 | --- | --- |
+| `"2018-01-01.md"` | `"2018-01-01"` |
 | `"2018-01-01-myFile.md"` | `"myFile"` |
 | `"myDir/myFile.md"` | `"myFile"` |
 


### PR DESCRIPTION
Docs didn't explicitly indicate what fileSlug does to inputPaths like `2018-01-01.md` (without `-myFile` at the end) so I thought it would be helpful to explicitly show that.