### PR TITLE
Add three sites built with Eleventy 🎈

### DIFF
--- a/_data/sites/docs-getchip-cc.json
+++ b/_data/sites/docs-getchip-cc.json
@@ -1,0 +1,8 @@
+{
+	"url": "https://docs.getchip.cc/",
+	"name": "Next Thing Co. Docs",
+	"description": "A mirror of the defunct Next Thing Co. documentation website.",
+	"twitter": "jgarber",
+	"authoredBy": [],
+	"source_url": "https://github.com/jgarber623/docs.getchip.cc"
+}

--- a/_data/sites/sketchnotes-sixtwothree-org.json
+++ b/_data/sites/sketchnotes-sixtwothree-org.json
@@ -1,0 +1,8 @@
+{
+	"url": "https://sketchnotes.sixtwothree.org/",
+	"name": "sketchnotes.sixtwothree.org",
+	"description": "Notes that aren’t really sketches.",
+	"twitter": "jgarber",
+	"authoredBy": [],
+	"source_url": "https://github.com/jgarber623/sketchnotes.sixtwothree.org"
+}

--- a/_data/sites/whoistheorchid-com.json
+++ b/_data/sites/whoistheorchid-com.json
@@ -1,0 +1,8 @@
+{
+	"url": "https://whoistheorchid.com/",
+	"name": "The Orchid",
+	"description": "Website for Washington, DC, instrumental post-rock band The Orchid.",
+	"twitter": "jgarber",
+	"authoredBy": [],
+	"source_url": "https://github.com/jgarber623/whoistheorchid.com"
+}


### PR DESCRIPTION
This PR adds data files for three websites I've built with Eleventy:

- https://docs.getchip.cc/ – A mirror of the defunct Next Thing Co. documentation website.
- https://sketchnotes.sixtwothree.org/ – Notes that aren’t really sketches.
- https://whoistheorchid.com/ – Website for Washington, DC, instrumental post-rock band The Orchid.

Thanks for all your hard work building and maintaining Eleventy! 👏🏻