### PR TITLE
Refine url filter examples

### DIFF
--- a/docs/filters/url.md
+++ b/docs/filters/url.md
@@ -15,7 +15,8 @@ _If you don’t need `pathPrefix` (or don’t ever plan on moving your site’s 
 
 {% raw %}
 ```html
-<a href="{{ post.url | url }}">Liquid or Nunjucks Link</a>
+<a href="{{ '/myDir/' | url }}">Liquid or Nunjucks Link (from string)</a>
+<a href="{{ post.url | url }}">Liquid or Nunjucks Link (from variable)</a>
 ```
 {% endraw %}
 
@@ -23,24 +24,24 @@ _If you don’t need `pathPrefix` (or don’t ever plan on moving your site’s 
 
 | Sample URL   | `pathPrefix` | Return value                                                                           |
 | ------------ | ------------ | -------------------------------------------------------------------------------------- |
-| `''`         | `'/'`        | `'.'` ⚠️ This style is probably not what you want—careful!                             |
+| `''`         | `'/'`        | `'.'` ⚠️ This style is probably not what you want—careful!                              |
 | `'/'`        | `'/'`        | `'/'`                                                                                  |
 | `'./'`       | `'/'`        | `'./'`                                                                                 |
 | `'..'`       | `'/'`        | `'..'`                                                                                 |
-| `'myDir'`    | `'/'`        | `'myDir'` ⚠️ This style is not safe for globally linking to other content. Be careful! |
-| `'/myDir'`   | `'/'`        | `'/myDir'`                                                                             |
-| `'./myDir'`  | `'/'`        | `'myDir'` ⚠️ This style is not safe for globally linking to other content. Be careful! |
-| `'../myDir'` | `'/'`        | `'../myDir'`                                                                           |
+| `'myDir'`    | `'/'`        | `'myDir'` ⚠️ This style is not safe for globally linking to other content. Be careful!  |
+| `'/myDir/'`  | `'/'`        | `'/myDir/'`                                                                            |
+| `'./myDir/'` | `'/'`        | `'myDir/'` ⚠️ This style is not safe for globally linking to other content. Be careful! |
+| `'../myDir/'` | `'/'`       | `'../myDir/'`                                                                          |
 
-| Sample URL   | `pathPrefix` | Return value                                                   |
-| ------------ | ------------ | -------------------------------------------------------------- |
-| `''`         | `'/rootDir'` | `'.'` ⚠️ This style is probably not what you want—careful!     |
-| `'/'`        | `'/rootDir'` | `'/rootDir/'`                                                  |
-| `'./'`       | `'/rootDir'` | `'./'`                                                         |
-| `'..'`       | `'/rootDir'` | `'..'`                                                         |
-| `'myDir'`    | `'/rootDir'` | `'myDir'` ⚠️ This style is probably not what you want—careful! |
-| `'/myDir'`   | `'/rootDir'` | `'/rootDir/myDir'`                                             |
-| `'./myDir'`  | `'/rootDir'` | `'myDir'` ⚠️ This style is probably not what you want—careful! |
-| `'../myDir'` | `'/rootDir'` | `'../myDir'`                                                   |
+| Sample URL   | `pathPrefix`  | Return value                                                   |
+| ------------ | ------------- | -------------------------------------------------------------- |
+| `''`         | `'/rootDir/'` | `'.'` ⚠️ This style is probably not what you want—careful!      |
+| `'/'`        | `'/rootDir/'` | `'/rootDir/'`                                                  |
+| `'./'`       | `'/rootDir/'` | `'./'`                                                         |
+| `'..'`       | `'/rootDir/'` | `'..'`                                                         |
+| `'myDir'`    | `'/rootDir/'` | `'myDir'` ⚠️ This style is probably not what you want—careful!  |
+| `'/myDir/'`  | `'/rootDir/'` | `'/rootDir/myDir/'`                                            |
+| `'./myDir/'` | `'/rootDir/'` | `'myDir/'` ⚠️ This style is probably not what you want—careful! |
+| `'../myDir/'` | `'/rootDir/'` | `'../myDir/'`                                                 |
 
 * [← Back to Filters documentation.](/docs/filters/)


### PR DESCRIPTION
1. Add string type to link example. 
2. Add closing slash to Transformations table Sample URLs  to be consistent with documentation -- https://www.11ty.dev/docs/permalinks/#remapping-output-(permalink)
3. Add closing slash to Transformations table `pathPrefix` to be consistent with first paragraph of this page.