### PR TITLE
[DOCS] Remove duplicate content typo

### DIFF
--- a/docs/quicktips/edit-on-github-links.md
+++ b/docs/quicktips/edit-on-github-links.md
@@ -24,7 +24,7 @@ Here’s a sample:
 
 ## Add our link!
 
-Edit your your layout file to add the link. Provide the URL to the base of your repo and use the Eleventy provided {% raw %}`{{ page.inputPath }}`{% endraw %} variable to point to the correct input file. Yes, this will also work with paginated templates.
+Edit your layout file to add the link. Provide the URL to the base of your repo and use the Eleventy provided {% raw %}`{{ page.inputPath }}`{% endraw %} variable to point to the correct input file. Yes, this will also work with paginated templates.
 
 {% raw %}
 ```html


### PR DESCRIPTION
Removed a duplicate `your` entry.