### PR TITLE
New site: HamsterSquare

### DIFF
--- a/_data/sites/hamstersquare.json
+++ b/_data/sites/hamstersquare.json
@@ -1,0 +1,8 @@
+{
+	"url": "https://www.hamstersquare.de/",
+	"name": "HamsterSquare",
+	"description": "German website for keeping hamsters as pets.",
+	"twitter": "",
+	"authoredBy": "dennisview",
+	"source_url": ""
+}


### PR DESCRIPTION
Added hamstersquare.de, a german website for keeping hamsters as pets.