### PR TITLE
Write docs for config events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,50 @@
+---
+eleventyNavigation:
+  parent: Configuration
+  key: Events
+  order: 10
+---
+
+# Events {% addedin "0.11.0" %}
+
+You may want to run some code at certain times during the compiling process. To do that, you can use _configuration events_, which will run at specific times during the compiling process.
+
+[[toc]]
+
+All events are configured in your `.eleventy.js` configuration file, with the code run every time the event triggers.
+
+## beforeBuild
+
+The `beforeBuild` event runs every time Eleventy starts building, so it will run before the start of each stand-alone build, as well as each time building starts as either part of `--watch` or `--serve`. To use it, attach the event handler to your Eleventy config:
+
+```js
+module.exports = function (eleventyConfig) {
+  eleventyConfig.on('beforeBuild', () => {
+    // Run me before the build starts
+  });
+};
+```
+
+## afterBuild
+
+The `afterBuild` event runs every time Eleventy finishes building, so it will run after the end of each stand-alone build, as well as each time building ends as either part of `--watch` or `--serve`. To use it, attach the event handler to your Eleventy config:
+
+```js
+module.exports = function (eleventyConfig) {
+  eleventyConfig.on('afterBuild', () => {
+    // Run me after the build ends
+  });
+};
+```
+
+## beforeWatch
+
+The `beforeWatch` event runs before a build is run _only_ if it's a re-run during `--watch` or `--serve`. This means it will neither run during the initial build nor during stand-alone builds. To use it, attach the event handler to your Eleventy config:
+
+```js
+module.exports = function (eleventyConfig) {
+  eleventyConfig.on('beforeWatch', () => {
+    // Run me before --watch or --serve re-runs
+  });
+};
+```


### PR DESCRIPTION
Basic documentation of configuration events. As this is net-new and not previously documented, I did my best to get the format and placing correct. I think the only thing missing from the docs, and something I'm not sure of myself or not, is if events block further action or not. I don't believe they do, but with confirmation that can be added to these docs. I'm assuming this will be available in `0.11.0`

Includes docs for https://github.com/11ty/eleventy/pull/1143

Resolves https://github.com/11ty/eleventy/issues/1042
