### PR TITLE
Animation optimalization

### DIFF
--- a/_includes/index.css
+++ b/_includes/index.css
@@ -2,7 +2,7 @@
 .sr-only {
 	position: absolute;
 	height: 1px;
-	width: 1px; 
+	width: 1px;
 	overflow: hidden;
 	clip: rect(1px, 1px, 1px, 1px);
 }
@@ -398,7 +398,6 @@ footer.elv-layout {
 @media (prefers-reduced-motion: reduce) {
 	.elv-header-default .elv-possum {
 		display: none;
-		animation: none;
 	}
 }
 @keyframes balloonFloat {

--- a/_includes/index.css
+++ b/_includes/index.css
@@ -402,12 +402,10 @@ footer.elv-layout {
 }
 @keyframes balloonFloat {
 	from {
-		top: 50%;
-		left: -5%;
+		transform: translate(-7vw, 30%);
 	}
 	to {
-		top: 5%;
-		left: 120%;
+		transform: translate(100vw, -52%);
 	}
 }
 


### PR DESCRIPTION
My possum was shaking like hell on my way-too-wide monitor, so I though we might give the beast a smooth flight using transforms.

Changes:
- Remove redundant `animation: none` when the element is hidden
- Use transforms for the animation

Ref.https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/