### PR TITLE
Update brycewray.json for new source repo URL

### DIFF
--- a/_data/sites/brycewray.json
+++ b/_data/sites/brycewray.json
@@ -2,6 +2,6 @@
   "name": "Bryce Wray",
   "url": "https://brycewray.com",
   "twitter": "BryceWrayTX",
-  "source_url": "https://github.com/brycewray/eleventy_bundler",
+  "source_url": "https://github.com/brycewray/eleventy_solo",
   "description": "Just an old fart on the Internet — Opinions, observations, geekery."
 }


### PR DESCRIPTION
Now that brycewray.com is using a different repo, submitting this as a PR.