### PR TITLE
Remove exclusionary language

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -382,7 +382,7 @@ _(More discussion at [Issue #194](https://github.com/11ty/eleventy/issues/194))_
 
 As an aside, this could also be achieved in a more verbose way using the [Collection API](/docs/collections/#advanced-custom-filtering-and-sorting). This could also be done using the new `before` callback {% addedin "0.10.0" %}.
 
-### Blacklisting or Filtering Values {% addedin "0.4.0" %}
+### Filtering Values {% addedin "0.4.0" %}
 
 Use the `filter` pagination property to remove values from paginated data.
 

--- a/docs/quicktips/tag-pages.md
+++ b/docs/quicktips/tag-pages.md
@@ -60,7 +60,7 @@ The great thing here is that we don’t have to manage our tag list in a central
 
 ## Filtering / Excluding
 
-Have a tag you’d like to exclude from this list? Use [pagination filtering](/docs/pagination/#blacklisting-or-filtering-values) like this:
+Have a tag you’d like to exclude from this list? Use [pagination filtering](/docs/pagination/#filtering-values) like this:
 
 {% raw %}
 ```markdown


### PR DESCRIPTION
From <https://www.ncsc.gov.uk/blog-post/terminology-its-not-black-and-white>:

> It only makes sense if you equate **white** with 'good, permitted, safe' and **black** with 'bad, dangerous, forbidden'. There are some obvious problems with this. 

Upon being made aware of language being used in this way, it becomes hard to ignore.

I have removed the word _blacklisting_; I’m not sure an alternative word is needed in this instance as saying _filtering_ should be enough.