### PR TITLE
make clearer how to use a prism theme in 11ty

### DIFF
--- a/docs/plugins/syntaxhighlight.md
+++ b/docs/plugins/syntaxhighlight.md
@@ -40,7 +40,18 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-You are responsible for including [your favorite PrismJS theme CSS](https://github.com/PrismJS/prism-themes)!
+You are responsible for including your favorite PrismJS theme CSS and there are many ways to do that. The default themes are provided by [several CDNs](https://prismjs.com/#basic-usage-cdn) and could be easly included in a base layout, like in the example bellow;
+
+```html
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link href="https://unpkg.com/browse/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
+  </head>
+````
+
+You could also download the css file or paste its content inside a style tag. This aprroach opens the opportunity to use other themes like [these ones](https://github.com/PrismJS/prism-themes) from a Prism extension repository.
 
 ### Options
 


### PR DESCRIPTION
the original text points to a git theme repository. in my case i also reached to prism official site and enjoyed one of their default themes. at first i thought i should grab the css from the git repository mentioned be 11ty, but the default themes are not there. then i struggled to discover the cdn approach to include the css. after a while i was able to solve everything, but kept the thought that an example of how to include a prism theme could help other noobs like me 😃.

i love 11ty by the way. thank you.