### PR TITLE
Eleventy Starter Ghost updated for Ghost 3.0

### DIFF
--- a/_data/sites/ghost-v3.json
+++ b/_data/sites/ghost-v3.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://ghost-v3.netlify.app/",
+	"name": "Eleventy Starter Ghost v3",
+	"description": "A starter template to build completely static websites with Ghost 3.0 & Eleventy",
+	"twitter": "bauhouse",
+	"source_url": "https://github.com/bauhouse/eleventy-starter-ghost"
+}


### PR DESCRIPTION
[Eleventy Starter Ghost for version 3.0](https://community.netlify.com/t/eleventy-starter-ghost-for-version-3-0/15050?u=bauhouse)

The [Eleventy Starter Ghost](https://github.com/TryGhost/eleventy-starter-ghost) template has been updated for Ghost 3.0.

The Deploy to Netlify button is working well so far.

[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bauhouse/eleventy-starter-ghost)

- **GitHub:** [Eleventy Starter Ghost for version 3.0](https://github.com/bauhouse/eleventy-starter-ghost)
- **Demo:** <https://ghost-v3.netlify.app/>

If anyone has some insight into [this issue](https://github.com/TryGhost/eleventy-starter-ghost/pull/22#issuecomment-630922022), it would be great to resolve this before the Jamstack Conf Virtual.