### PR TITLE
Incorrect closing tag

### DIFF
--- a/docs/languages/liquid.md
+++ b/docs/languages/liquid.md
@@ -201,7 +201,7 @@ Note that you can put any Liquid tags or content inside the `{% raw %}{% user %}
 ```html
 {% user2 "Zach Leatherman" "zachleat" %}
   Zach likes to take long walks on Nebraska beaches.
-{% enduser %}
+{% enduser2 %}
 ```
 {% endraw %}
 


### PR DESCRIPTION
On the liquid page documentation page :https://www.11ty.dev/docs/languages/liquid/#shortcodes

In the example that precedes the text "Note that you can put any Liquid tags or content inside ...", if I am not misunderstanding the documentation, it should close with enduser2 and not enduser.

It caused me a little confusion, being relatively new to the liquid syntax.