### PR TITLE
Fix to syntax highlighting of JS example in layout-chaining docs

### DIFF
--- a/_includes/examples/layout-chaining/mainlayout.11ty.js
+++ b/_includes/examples/layout-chaining/mainlayout.11ty.js
@@ -1,5 +1,4 @@
 {% raw %}
-```js
 exports.data = {
   layout: "mylayout.njk",
   myOtherData: "hello"
@@ -10,5 +9,4 @@ exports.render = function(data) {
     ${data.content}
   </main>`;
 };
-```
 {% endraw %}


### PR DESCRIPTION
I love Eleventy, thank you so much for the wonderful project. First time sending in a pull request, so please don't hesitate to let me know if I didn't follow the right procedures.

Fixes this following issue:

<img width="1004" alt="Screenshot 2020-06-11 at 07 59 02" src="https://user-images.githubusercontent.com/51175441/84350507-b1e38980-abb9-11ea-9016-bdd7fa56a924.png">
