### PR TITLE
Webpack starter with multiple bundles and chunks

### DIFF
--- a/_data/starters/eleventy-webpack-chunks.json
+++ b/_data/starters/eleventy-webpack-chunks.json
@@ -1,0 +1,6 @@
+{
+	"url": "https://github.com/kjugi/eleventy-webpack-chunks",
+	"name": "11ty with webpack multiple bundles",
+	"description": "11ty + webpack + nunjucks - Simple static website, well fits as about me page with blog.",
+	"author": "kjugi"
+}


### PR DESCRIPTION
Yet another example of webpack usage with eleventy. In this example repo, I'm showing how to configure 11ty with webpack multiple entry points and splitting chunks. As an addition, we also have extracting CSS styles to separate files from.

This demo has one important restriction that we can't use 11ty `--serve` flag to host app. That's also mentioned in README.

Watch commend is running at the same time for both tasks. Webpack is watching changes in js files and eleventy in njk files.