### PR TITLE
Updating suggested URL for CSS file

### DIFF
--- a/docs/plugins/syntaxhighlight.md
+++ b/docs/plugins/syntaxhighlight.md
@@ -46,7 +46,7 @@ You are responsible for including your favorite PrismJS theme CSS and there are 
 <html lang="en">
   <head>
     <!-- Some html boilerplate omitted -->
-    <link href="https://unpkg.com/browse/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
+    <link href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css" rel="stylesheet">
   </head>
 ````
 


### PR DESCRIPTION
Currently, the suggested URL (<https://unpkg.com/browse/prismjs@1.20.0/themes/prism-okaidia.css>) does not link to a raw CSS file