### PR TITLE
Add eleventy-plugin-sitemap to plugin list

### DIFF
--- a/_data/plugins/eleventy-plugin-sitemap.json
+++ b/_data/plugins/eleventy-plugin-sitemap.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-sitemap",
+	"author": "nunof07",
+	"description": "adds a shortcode for generating a sitemap."
+}

--- a/_data/plugins/eleventy-plugin-sitemap.json
+++ b/_data/plugins/eleventy-plugin-sitemap.json
@@ -1,5 +1,5 @@
 {
-	"npm": "eleventy-plugin-sitemap",
+	"npm": "@quasibit/eleventy-plugin-sitemap",
 	"author": "nunof07",
 	"description": "adds a shortcode for generating a sitemap."
 }


### PR DESCRIPTION
A plugin that adds a shortcode for generating a sitemap.

https://github.com/quasibit/eleventy-plugin-sitemap
https://www.npmjs.com/package/eleventy-plugin-sitemap