### PR TITLE
Remove treypiepmeier.com.

### DIFF
--- a/_data/sites/treypiepmeier.json
+++ b/_data/sites/treypiepmeier.json
@@ -1,7 +1,0 @@
-{
-	"url": "https://treypiepmeier.com/",
-	"name": "Trey Piepmeier dot com",
-	"description": "Trey Piepmeier’s personal website and blog.",
-	"twitter": "trey",
-	"source_url": "https://github.com/trey/treypiepmeier"
-}


### PR DESCRIPTION
This code isn’t public anymore for the time being.