### PR TITLE
Add Eleventy Solo Starter

### DIFF
--- a/_data/starters/eleventy-solo-starter.json
+++ b/_data/starters/eleventy-solo-starter.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/brycewray/eleventy_solo_starter",
+	"name": "Eleventy Solo Starter",
+	"description": "Eleventy starter with PostCSS, Tailwind CSS, Lazyload (“vanilla lazyload”), and build-time creation and processing of responsive images.",
+	"author": "BryceWrayTX",
+	"demo": "https://eleventy-solo-starter.netlify.app/"
+}


### PR DESCRIPTION
I request that my starter be added. The relevant file is `_data/starters/eleventy-solo-starter.json` and consists of the following:

```
{
	"url": "https://github.com/brycewray/eleventy_solo_starter",
	"name": "Eleventy Solo Starter",
	"description": "Eleventy starter with PostCSS, Tailwind CSS, Lazyload (“vanilla lazyload”), and build-time creation and processing of responsive images.",
	"author": "BryceWrayTX",
	"demo": "https://eleventy-solo-starter.netlify.app/"
}
```

Thanks!