### PR TITLE
Typo on output path of using pagination.

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -98,7 +98,7 @@ In addition to the `pagination` object entries documented above, it also has:
 
 </details>
 
-If the above file were named `paged.njk`, it would create two pages: `_site/paged/0/index.html` and `_site/paged/1/index.html`. These output paths are configurable with `permalink` (see below).
+If the above file were named `paged.njk`, it would create two pages: `_site/paged/index.html` and `_site/paged/1/index.html`. These output paths are configurable with `permalink` (see below).
 
 ## Creating Navigation Links to your Pages
 


### PR DESCRIPTION
If I'm correct.

Enabling pagination on a file named paged.njk will output:
`_site/paged/index.html` and `_site/paged/1/index.html`.

Instead of:
`_site/paged/0/index.html`
