### PR TITLE
[Inline Minified JavaScript tip] Update code sample to new async Terser minify

### DIFF
--- a/docs/quicktips/inline-js.md
+++ b/docs/quicktips/inline-js.md
@@ -28,7 +28,7 @@ eleventyConfig.addNunjucksAsyncFilter("jsmin", async function (
     const minified = await minify(code);
     callback(null, minified.code);
   } catch (err) {
-    console.error('Terser error: ', err);
+    console.error("Terser error: ", err);
     // Fail gracefully.
     callback(null, code);
   }

--- a/docs/quicktips/inline-js.md
+++ b/docs/quicktips/inline-js.md
@@ -20,14 +20,18 @@ Add the following `jsmin` filter to your Eleventy Config file:
 
 ```js
 const { minify } = require("terser");
-  eleventyConfig.addNunjucksAsyncFilter("jsmin", async function (code, callback) {
-  const minified = await minify(code);
-  if (minified.error) {
-    console.error("Terser error: ", minified.error);
+eleventyConfig.addNunjucksAsyncFilter("jsmin", async function (
+  code,
+  callback
+) {
+  try {
+    const minified = await minify(code);
+    callback(null, minified.code);
+  } catch (err) {
+    console.error('Terser error: ', err);
     // Fail gracefully.
-    return callback(null, code);
+    callback(null, code);
   }
-  return callback(null, minified.code);
 });
 ```
 

--- a/docs/quicktips/inline-js.md
+++ b/docs/quicktips/inline-js.md
@@ -19,15 +19,15 @@ This tip works great if you have small JS utilities that you’d like to have in
 Add the following `jsmin` filter to your Eleventy Config file:
 
 ```js
-const Terser = require("terser");
-eleventyConfig.addFilter("jsmin", function(code) {
-    let minified = Terser.minify(code);
-    if( minified.error ) {
-        console.log("Terser error: ", minified.error);
-        return code;
-    }
-
-    return minified.code;
+const { minify } = require("terser");
+  eleventyConfig.addNunjucksAsyncFilter("jsmin", async function (code, callback) {
+  const minified = await minify(code);
+  if (minified.error) {
+    console.error("Terser error: ", minified.error);
+    // Fail gracefully.
+    return callback(null, code);
+  }
+  return callback(null, minified.code);
 });
 ```
 


### PR DESCRIPTION
Terser had a [breaking change](https://github.com/terser/terser/blob/master/CHANGELOG.md#user-content-v500-beta0:~:text=BREAKING%3A%20minify()%20is%20now%20async%20and%20rejects%20a%20promise%20instead%20of%20returning%20an%20error). This PR updates the code sample in the tip to reflect this.