### PR TITLE
Add 11r starter project

### DIFF
--- a/_data/starters/11r.json
+++ b/_data/starters/11r.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/reeseschultz/11r#readme",
+	"name": "11r",
+	"description": "A blog template and theme using 11ty, TailwindCSS, Rollup, Prism syntax highlighting, etc.",
+	"author": "TheReeseSchultz",
+	"demo": "https://reeseschultz.github.io/11r/"
+}


### PR DESCRIPTION
I request that [11r](https://github.com/reeseschultz/11r) be added to the list of starter projects. I created `_data/starters/11r.json` as follows:

```json
{
	"url": "https://github.com/reeseschultz/11r#readme",
	"name": "11r",
	"description": "A blog template and theme using 11ty, TailwindCSS, Rollup, Prism syntax highlighting, etc.",
	"author": "TheReeseSchultz",
	"demo": "https://reeseschultz.github.io/11r/"
}
```
Many thanks in advance for your time and consideration.