### PR TITLE
Add `eleventy-plugin-sharp` plugin

### DIFF
--- a/_data/plugins/eleventy-plugin-sharp.json
+++ b/_data/plugins/eleventy-plugin-sharp.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-sharp",
+	"author": "luwes",
+	"description": "will add the full power of Sharp's image processing to your templates."
+}


### PR DESCRIPTION
URL https://github.com/luwes/eleventy-plugin-sharp

In porting my website from Craft CMS to Eleventy I missed the more granular control of generating images. Something like https://craftcms.com/docs/3.x/image-transforms.html

https://github.com/11ty/eleventy-img is cool but it comes with some tradeoffs like having to create a shortcode for every variant of image, the output HTML is hidden from the template, the abstraction around it (probably intentionally) hides most of Sharp's features resulting in PR's like [#23](https://github.com/11ty/eleventy-img/pull/23), [#10](https://github.com/11ty/eleventy-img/pull/10)

This could be a good alternative for devs who don't mind more configuration in their templates.