### PR TITLE
Update and rename cassey-til.json to til-blog.json

### DIFF
--- a/_data/starters/cassey-til.json
+++ b/_data/starters/cassey-til.json
@@ -1,6 +1,0 @@
-{
-	"url": "https://glitch.com/~cassey-til",
-	"name": "eleventy-on-glitch by cassey-til",
-	"description": "A starter repository showing how to build a blog with the Eleventy static site generator.",
-	"author": "CasseyLottman"
-}

--- a/_data/starters/til-blog.json
+++ b/_data/starters/til-blog.json
@@ -1,0 +1,6 @@
+{
+	"url": "https://glitch.com/~til-blog",
+	"name": "til-blog",
+	"description": "A project showing a basic blog with tags, based on eleventy-base-blog and optimized for Glitch.",
+	"author": "CasseyLottman"
+}


### PR DESCRIPTION
Cassey-til is my actual blog, and I'd prefer people don't use it as a starter project since it's pre-populated with stuff about me, and my own blog posts. 

But! I have a cleaned up version, with detailed instructions on how to start using it in the readme, in another Glitch project. 