### PR TITLE
Update docs with `addGlobalData`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node-supporters/
 .env
 .log
 .cache
+yarn.lock 
+.vscode

--- a/_includes/datasources.md
+++ b/_includes/datasources.md
@@ -6,3 +6,4 @@ When the data is merged in the {% if page.url != "/docs/data-cascade/" %}[Eleven
 1. [Template Data Files](/docs/data-template-dir/){% if page.url == "/docs/data-template-dir/" %} ⬅{% endif %}
 1. [Directory Data Files (and ascending Parent Directories)](/docs/data-template-dir/){% if page.url == "/docs/data-template-dir/" %} ⬅{% endif %}
 1. [Global Data Files](/docs/data-global/){% if page.url == "/docs/data-global/" %} ⬅{% endif %}
+1. [Custom Global Data](/docs/data-global-custom/){% if page.url == "/docs/data-global-custom/" %} ⬅{% endif %}

--- a/docs/data-global-custom.md
+++ b/docs/data-global-custom.md
@@ -1,0 +1,35 @@
+---
+eleventyNavigation:
+  parent: Data Cascade
+  key: Global Data
+  order: 4
+---
+
+# Custom Global Data {% addedin "0.12.0" %}
+
+In addition to [Global Data Files](/docs/data-global/) global data can be added to the Eleventy config object using the `addGlobalData` method. This is especially useful for plugins.
+
+The first value of `addGlobalData` is the key that will be available to your templates and the second value is the value of the value returned to the template.
+
+## Example
+
+```js
+module.exports = function (eleventyConfig) {
+  // Values can be static:
+  eleventyConfig.addGlobalData("static", "static");
+  // functions:
+  eleventyConfig.addGlobalData("function", () => new Date());
+  // or async :
+  eleventyConfig.addGlobalData(
+    "async",
+    () =>
+      new Promise((resolve) => {
+        setTimeout(resolve, 100, "foo");
+      })
+  );
+};
+```
+
+## Sources of Data
+
+{% include "datasources.md" %}


### PR DESCRIPTION
Adds a page for custom global data with `addGlobalData`. 

Adds this to the `datasources.md` file meaning this is linked in the other section on data cascade and navigation.

Should be referenced anywhere else in docs?

Fixes: #1386