### PR TITLE
Instruct user to use npx in home page

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,9 +13,9 @@ bigPossum: true
 Eleventy {% latestVersion versions, config %} requires Node 8 or newer. Use `node --version` on the command line to find your local Node version.
 
 ``` bash
-npm install -g @11ty/eleventy
+npm install @11ty/eleventy
 echo '# Page header' > README.md
-eleventy
+npx @11ty/eleventy
 ```
 
 This will compile any files matching valid input [template file extensions](/docs/languages/) (`.md` is one of them) in the current directory into the output folder (defaults to `_site`).
@@ -25,7 +25,7 @@ Writing _site/README/index.html from ./README.md.
 Wrote 1 file in 0.11 seconds (v0.11.0)
 ```
 
-Run `eleventy --serve` to start up a web server. Then open `http://localhost:8080/README/` in your web browser of choice to see your Eleventy output.
+Run `npx @11ty/eleventy --serve` to start up a web server. Then open `http://localhost:8080/README/` in your web browser of choice to see your Eleventy output.
 
 ➡ Keep going! Read a longer [Getting Started guide](/docs/getting-started/) or check out the full [**Documentation for {% latestVersion versions, config %}**]({{ "/docs/" | url }}).
 


### PR DESCRIPTION
This command fails on some systems:

    npm install -g @11ty/eleventy

For instance, on Ubuntu 20.04 LTS, it fails with this error message:

    npm ERR! Error: EACCES: permission denied, access '/usr/local/lib'

These are instructions on how to start quickly... Let's use npx the way it was intended to be used. This matches documentation in other places.