### PR TITLE
Fix extra character typo in syntaxhighlight.md

### DIFF
--- a/docs/plugins/syntaxhighlight.md
+++ b/docs/plugins/syntaxhighlight.md
@@ -40,7 +40,7 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-You are responsible for including your favorite PrismJS theme CSS and there are many ways to do that. The default themes are provided by [several CDNs](https://prismjs.com/#basic-usage-cdn) and could be easily included in a base layout, like in the example bellow;
+You are responsible for including your favorite PrismJS theme CSS and there are many ways to do that. The default themes are provided by [several CDNs](https://prismjs.com/#basic-usage-cdn) and could be easily included in a base layout, like in the example below;
 
 ```html
 <html lang="en">


### PR DESCRIPTION
Hey! While reading through the docs for [Syntax Highlighting Plugin](https://www.11ty.dev/docs/plugins/syntaxhighlight/), I found this extra lowercase "l" character in "bellow" on [Line 43](https://github.com/11ty/11ty-website/blame/master/docs/plugins/syntaxhighlight.md#L43). 

Everything else on the page looks great and the syntax highlighter works like a charm. Thanks! @zachleat 