### PR TITLE
Update edit-on-github-links.md

### DIFF
--- a/docs/quicktips/edit-on-github-links.md
+++ b/docs/quicktips/edit-on-github-links.md
@@ -31,7 +31,7 @@ Edit your layout file to add the link. Provide the URL to the base of your repo 
     …
     <footer>
       © 2019 Eleventy
-      <a href="https://github.com/11ty/11ty-website/blob/master/{{ page.inputPath }}">Edit this page on GitHub</a>
+      <a href="https://github.com/11ty/11ty-website/blob/main/{{ page.inputPath }}">Edit this page on GitHub</a>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
This pr changes the branch name to github's new default in the "Quick Tip # 003—Add Edit on GitHub Links to All Pages".

Last August github's default branch name was changed to "main" (https://github.blog/changelog/2020-08-26-set-the-default-branch-for-newly-created-repositories/).

If you follow the quicktip article with a brand new repository and replace 11ty's org and repo with your own, the edit button will actually work, but a disclaimer like this will show up:

<img width="329" alt="Screen Shot 2020-10-18 at 12 57 24 AM" src="https://user-images.githubusercontent.com/2272928/96359864-25a02080-10dd-11eb-8dd3-4cfd070d1a72.png">

