### PR TITLE
fix: 🔎 Remove "njk" from syntax highlighting docs

### DIFF
--- a/docs/plugins/syntaxhighlight.md
+++ b/docs/plugins/syntaxhighlight.md
@@ -64,7 +64,7 @@ module.exports = function(eleventyConfig) {
     // Change which syntax highlighters are installed
     templateFormats: ["*"], // default
 
-    // Or, just liquid and md syntax highlighters
+    // Or, only liquid and md syntax highlighters
     // templateFormats: ["liquid", "md"],
 
     // init callback lets you customize Prism

--- a/docs/plugins/syntaxhighlight.md
+++ b/docs/plugins/syntaxhighlight.md
@@ -64,8 +64,8 @@ module.exports = function(eleventyConfig) {
     // Change which syntax highlighters are installed
     templateFormats: ["*"], // default
 
-    // Or, just njk and md syntax highlighters (do not install liquid)
-    // templateFormats: ["njk", "md"],
+    // Or, just liquid and md syntax highlighters
+    // templateFormats: ["liquid", "md"],
 
     // init callback lets you customize Prism
     init: function({ Prism }) {


### PR DESCRIPTION
PrismJS does not support Nunjucks, so "njk" is a bad example. Instead,
I've updated the doc example to load "liquid" and "md"

My understanding is the default behavior ("*") is to load all
languages, so explicitly saying there's one specific language we don't
load is confusing anyway.

Aside: My Prettier plugin went berzerk on this file, not sure if
there's any interest in using its formatting standards, but the next
person to pick this up will have to figure out how to separate their
changes from the formatting changes if they want to update it without
updating all the little formatting stuff.