### PR TITLE
Add sites: EMBl.org and Visual Framework

### DIFF
--- a/_data/sites/embl.json
+++ b/_data/sites/embl.json
@@ -1,0 +1,8 @@
+{
+	"url": "https://www.embl.org/",
+	"name": "EMBL | European Molecular Biology Laboratory",
+	"description": "The main site of the laboratory.",
+	"twitter": "embl",
+	"authoredBy": ["khawkins98", "StuRobson"],
+	"source_url": "https://gitlab.ebi.ac.uk/emblorg/embl-org-static-html-pages"
+}

--- a/_data/sites/visual-framework.json
+++ b/_data/sites/visual-framework.json
@@ -1,0 +1,8 @@
+{
+	"url": "https://stable.visual-framework.dev/",
+	"name": "Visual Framework for life science websites",
+	"description": "Good defaults for life science websites, plus compatibility with existing CSS and JS. Bring your Bootsrap, Angular or vanilla CSS code base.",
+	"twitter": "embl",
+	"authoredBy": ["khawkins98", "StuRobson"],
+	"source_url": "https://github.com/visual-framework/vf-core"
+}


### PR DESCRIPTION
This PR adds two projects:

- EMBL.org laboratory website
  - The code for this is linked, but is access restricted due to "internal policy". Not sure if a public codebase is a requirement?
- The Visual Framework
  - An in-development component library, which is sponsored by the EMBL.org project

Thanks for maintaining the dashboard, it's really neat!