### PR TITLE
Clarify that setting --input etc is better via config than cli

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ eleventy
 npx @11ty/eleventy --input=. --output=_site
 ```
 
-Read more about [`--input`](/docs/config/#input-directory) and [`--output`](/docs/config/#output-directory). Note that setting the input and output directories via a [config](https://www.11ty.dev/docs/config/) file is more reliable, especially when using tools like [`netlify dev`](https://docs.netlify.com/cli/get-started/#run-a-local-development-environment).
+Read more about [`--input`](/docs/config/#input-directory) and [`--output`](/docs/config/#output-directory). Note that setting the input and output directories via a [config](/docs/config/) file is more reliable, especially when using tools like [`netlify dev`](https://docs.netlify.com/cli/get-started/#run-a-local-development-environment).
 
 A hypothetical `template.md` in the current directory would be rendered to `_site/template/index.html`. Read more at [Permalinks](/docs/permalinks/).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ eleventy
 npx @11ty/eleventy --input=. --output=_site
 ```
 
-Read more about [`--input`](/docs/config/#input-directory) and [`--output`](/docs/config/#output-directory).
+Read more about [`--input`](/docs/config/#input-directory) and [`--output`](/docs/config/#output-directory). Note that setting the input and output directories via a [config](https://www.11ty.dev/docs/config/) file is more reliable, especially when using tools like [`netlify dev`](https://docs.netlify.com/cli/get-started/#run-a-local-development-environment).
 
 A hypothetical `template.md` in the current directory would be rendered to `_site/template/index.html`. Read more at [Permalinks](/docs/permalinks/).
 


### PR DESCRIPTION
Setting input and output directories via the cli commands doesn't work well with tools like netlify dev.