### PR TITLE
Add alternative Windows debug commands to debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -38,8 +38,18 @@ What is the difference between Local and [Global installation](/docs/global-inst
 </div>
 
 <div class="lo" style="--lo-stackpoint: 30em; --lo-margin-h: 1em; --lo-margin-v: .5em">
+	<div class="lo-c">Installed Locally Alternative</div>
+	<div class="lo-c lo-maxgrow">{% highlight "bash" %}env:DEBUG="Eleventy*"; npx @11ty/eleventy{% endhighlight %}</div>
+</div>
+
+<div class="lo" style="--lo-stackpoint: 30em; --lo-margin-h: 1em; --lo-margin-v: .5em">
 	<div class="lo-c">Installed Globally</div>
 	<div class="lo-c lo-maxgrow">{% highlight "bash" %}set DEBUG=Eleventy* & eleventy{% endhighlight %}</div>
+</div>
+
+<div class="lo" style="--lo-stackpoint: 30em; --lo-margin-h: 1em; --lo-margin-v: .5em">
+	<div class="lo-c">Installed Globally Alternative</div>
+	<div class="lo-c lo-maxgrow">{% highlight "bash" %}env:DEBUG="Eleventy*"; eleventy{% endhighlight %}</div>
 </div>
 
 Read more about [Windows environment variables](https://www.npmjs.com/package/debug#windows-command-prompt-notes).


### PR DESCRIPTION
I struggled for a while to get debugging running on windows. 

The formatting of the command to set the debug value didn't work for me, but using the formatting from this issue [https://github.com/getgauge/taiko/issues/1065](https://github.com/getgauge/taiko/issues/1065) solved my problem. 

So I've added adding this to the document for both local and global installations. It should save anyone else from having to dig around for the same information to get it working.

For the record I'm not 100% happy with the way I've named these additions or how I've organised them. But the information itself was valuable.