### PR TITLE
Add a WordPress API example

### DIFF
--- a/_data/starters/wp-11ty.json
+++ b/_data/starters/wp-11ty.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/jhackett1/wp-11ty/",
+	"name": "WP 11ty",
+	"description": "A minimal example showing how to use the WordPress API to drive a static Eleventy frontend.",
+	"author": "jhackett1",
+	"demo": "https://githubbox.com/jhackett1/wp-11ty/"
+}


### PR DESCRIPTION
I've found an example showing how to [_fully convert_ a wordpress site to 11ty](https://www.11ty.dev/docs/tutorials/), but nothing showing the less extravagant use case of building pages off the API. That's what this aims to demonstrate.

I took a susprisingly long time to understand how this was done - it turned out I was drastically overcomplicating it! Perhaps this will help others.

[Here's a tutorial I wrote](https://blog.wearefuturegov.com/toward-the-minimum-viable-decoupled-website-4a57bba18f7f) outlining the same principles.