### PR TITLE
not-found: Run res.writeHead before res.write

### DIFF
--- a/docs/quicktips/not-found.md
+++ b/docs/quicktips/not-found.md
@@ -58,11 +58,10 @@ module.exports = function(eleventyConfig) {
 
         bs.addMiddleware("*", (req, res) => {
           const content_404 = fs.readFileSync('_site/404.html');
+          // Add 404 http status code in request header.
+          res.writeHead(404, { "Content-Type": "text/html; charset=UTF-8" });
           // Provides the 404 content without redirect.
           res.write(content_404);
-          // Add 404 http status code in request header.
-          // res.writeHead(404, { "Content-Type": "text/html" });
-          res.writeHead(404);
           res.end();
         });
       }


### PR DESCRIPTION
Otherwise the status comes out as “`HTTP/1.1 404 OK`” rather than “`HTTP/1.1 404 Not Found`”.

Also, set a Content-Type with a charset.