### PR TITLE
staticgen.com is now jamstack.org

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,4 +40,4 @@ This project aims to directly compete with all other Static Site Generators. We 
 * [Hexo](https://hexo.io/) (JavaScript)
 * [Gatsby](https://www.gatsbyjs.org/) (JavaScript using React)
 * [Nuxt](https://www.staticgen.com/nuxt) (JavaScript using Vue)
-* _More at [staticgen.com](https://www.staticgen.com/)_
+* _More at [jamstack.org](https://jamstack.org/generators/)_


### PR DESCRIPTION
https://jamstack.org/generators/ added instead of staticgen.com