### PR TITLE
Update collections.md

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -9,6 +9,8 @@ eleventyNavigation:
 
 While [pagination](/docs/pagination/) allows you to iterate over a data set to create multiple templates, a collection allows you to group content in interesting ways. A piece of content can be a part of multiple collections, if you assign the same string value to the `tags` key in the front matter.
 
+{% callout "warn" %}Terminology : in eleventy, `tags` are used to construct collections of content. It is different from `tags` referring to a hierarchy of labels as you can find in blogging platforms.{% endcallout %}
+
 ## A Blog Example
 
 For a blog site, your individual post files may use a tag called `post`, but it can be whatever you want. In this example, `mypost.md` has a single tag `post`:


### PR DESCRIPTION
Added a warning about 'tags' terminology. As quoted here by Josh Cunningham : https://www.joshcanhelp.com/taking-wordpress-to-eleventy/
it may be confusing coming from Wordpress or any blogging platform : 
Things can get a bit confusing here as we're going to start to overlap terminology a bit between the two platforms. In Eleventy, tags are used to construct collections of content. In WordPress, tags are just a type of taxonomy with no hierarchy.

As I'm not an native english speaker, I'm not sure about the way of writing this warning...