### PR TITLE
Fixed syntax error in pagination example.

### DIFF
--- a/_includes/examples/pagination/paged-array.11ty.js
+++ b/_includes/examples/pagination/paged-array.11ty.js
@@ -16,7 +16,7 @@ exports.render = function(data) {
   return `<ol>
     ${data.pagination.items.map(function(item) {
         return `<li>${item}</li>`;
-      }).join("");
+      }).join("")
     }
   </ol>`;
 };


### PR DESCRIPTION
This fixes the `paged-array.11ty.js` example at https://www.11ty.dev/docs/pagination/ that currently has incorrect syntax which fails the build.