### PR TITLE
fix: update plugin author

### DIFF
--- a/_data/plugins/eleventy-plugin-emoji.json
+++ b/_data/plugins/eleventy-plugin-emoji.json
@@ -1,5 +1,5 @@
 {
   "npm": "eleventy-plugin-emoji",
-  "author": "seanmcp",
+  "author": "snmcp",
   "description": "An accessible emoji shortcode and filter for your Eleventy projects"
 }


### PR DESCRIPTION
Using my Twitter handle instead of GitHub.

For what it's worth, I would rather have this plugin associated with my GitHub account than Twitter.