### PR TITLE
Async shortcodes can't be used in Nunjucks macros

### DIFF
--- a/docs/plugins/image.md
+++ b/docs/plugins/image.md
@@ -163,7 +163,7 @@ While we do prevent raster images from upscaling (and filter upscaling `widths` 
 
 ### Use this in your templates
 
-{% callout "info" %}The examples below use a <a href="/docs/languages/nunjucks/#asynchronous-shortcodes">Nunjucks</a> <code>async</code> shortcode (different from the traditional shortcode configuration method). The <a href="/docs/languages/javascript/#asynchronous-javascript-template-functions">JavaScript</a> and <a href="/docs/languages/liquid/#asynchronous-shortcodes">Liquid</a> template engines also work here and are asynchronous without additional changes.{% endcallout %}
+{% callout "info" %}The examples below use a <a href="/docs/languages/nunjucks/#asynchronous-shortcodes">Nunjucks</a> <code>async</code> shortcode (different from the traditional shortcode configuration method). The <a href="/docs/languages/javascript/#asynchronous-javascript-template-functions">JavaScript</a> and <a href="/docs/languages/liquid/#asynchronous-shortcodes">Liquid</a> template engines also work here and are asynchronous without additional changes. Note that <a href="https://mozilla.github.io/nunjucks/templating.html#macro">Nunjucks macros cannot use asynchronous shortcodes</a>. If you use macros, use Synchronous shortcodes described below.{% endcallout %}
 
 <seven-minute-tabs>
   <div role="tablist" aria-label="Easy or DIY mode chooser">


### PR DESCRIPTION
Clarified that Async shortcodes can't be used in Nunjucks macros. Related to: https://github.com/11ty/eleventy/issues/1613#issuecomment-769389637 and https://github.com/11ty/eleventy-img/issues/56