### PR TITLE
feat: add hidden sites field for DuckDuckGo search

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -10,7 +10,8 @@ css:
 	<div class="search-lo lo">
 		<div class="lo-c lo-maxgrow">
 			<label for="search-term" class="sr-only">Search Terms</label>
-			<input type="search" name="q" id="search-term" value="site:www.11ty.dev " class="search-txt" autocomplete="off">
+			<input type="search" name="q" id="search-term" class="search-txt" autocomplete="off">
+      <input aria-hidden="true" hidden name="sites" value="www.11ty.dev">
 		</div>
 		<div class="lo-c">
 			<button type="submit" class="search-btn btn-form">Search</button>


### PR DESCRIPTION
DuckDuckGo supports a `sites` search parameter that can scope your searches. Rather than including `site:www.11ty.dev` in the query value, you can set it automatically using a hidden field.

With these changes, the resulting action for a "collections" query will be: https://duckduckgo.com/?sites=www.11ty.dev&q=collections

<img width="672" alt="image" src="https://user-images.githubusercontent.com/6360367/106902149-7d7f8900-66c6-11eb-8f8b-51941ab6155b.png">

**Full disclosure**: I made this change from the GitHub UI, so I can't confirm that the hidden field is styled correctly, so feel free to edit as you see fit. But something along these lines might make for a nice improvement to the search experience.