### PR TITLE
add community contributions to language pages; add link to JS page

### DIFF
--- a/_includes/layouts/docs.njk
+++ b/_includes/layouts/docs.njk
@@ -16,7 +16,9 @@ isDocs: true
 </nav>
 {% endif %}
 {% if pageTitle %}<h1>{{ pageTitle | safe }}</h1>{% endif %}
+{% if not overrideCommunityLinks %}
 {% include "community-contributed.njk" %}
+{% endif %}
 
 {{ content | safe }}
 

--- a/_includes/layouts/langs.njk
+++ b/_includes/layouts/langs.njk
@@ -1,5 +1,6 @@
 ---
 layout: layouts/docs.njk
+overrideCommunityLinks: true
 ---
 <h1>{{ eleventyNavigation.key }}{% if addedInVersion %}{% addedin addedInVersion%}{% endif %}</h1>
 
@@ -7,5 +8,7 @@ layout: layouts/docs.njk
 <h2 class="elv-langlist-hed">Template Languages:</h2>
 {% templatelangs templatetypes, page %}
 </div>
+
+{% include "community-contributed.njk" %}
 
 {{ content | safe }}

--- a/docs/languages/javascript.md
+++ b/docs/languages/javascript.md
@@ -11,6 +11,10 @@ tags:
   - related-shortcodes
 relatedLinks:
   /docs/config/#watch-javascript-dependencies: Watch JavaScript Dependencies
+communityLinks:
+- url: https://willmartin.dev/posts/conditional-rendering-eleventy/
+  author: willmartindev
+  title: Conditionally Rendering JavaScript Templates
 layout: layouts/langs.njk
 ---
 | Eleventy Short Name | File Extension | NPM Package |


### PR DESCRIPTION
1. The community-contributions component did not play well with the pages in `docs/languages` due to some layout issues. I fixed this by adding an override to `layouts/langs.njk` and then checking for that override in `layouts/docs.njk`.
2. After enabling community contributions on language pages, I added a contribution link to the JavaScript language page: https://willmartin.dev/posts/conditional-rendering-eleventy/

Cheers!

