### PR TITLE
Add microsite to starters

### DIFF
--- a/_data/starters/microsite.json
+++ b/_data/starters/microsite.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/voightco/micro-site/",
+	"name": "microsite",
+	"description": "Opinionated micro front-end that sets common 11ty defaults. Great for creating landing pages.",
+	"author": "dandevri",
+	"demo": "https://voight-microsite.netlify.app"
+}


### PR DESCRIPTION
👋 I've created a couple of landing pages for clients and own projects with 11ty. I always started from scratch so  I created a more modular approach to creating one-pagers. That's why I've created micro-site. 

It's a opinionated micro front-end that can be used to create a one-pager. It sets common 11ty defaults and creates modular includes for metadata.

```
{
	"url": "https://github.com/voightco/micro-site/",
	"name": "microsite",
	"description": "Opinionated micro front-end that sets common 11ty defaults. Great for creating landing pages.",
	"author": "dandevri",
	"demo": "https://voight-microsite.netlify.app"
}
```