### PR TITLE
[eleventy-img docs] Add src to generateHTML imageAttributes examples

### DIFF
--- a/docs/plugins/image.md
+++ b/docs/plugins/image.md
@@ -193,6 +193,7 @@ async function imageShortcode(src, alt, sizes) {
   let imageAttributes = {
     alt,
     sizes,
+    src,
     loading: "lazy",
     decoding: "async",
   };
@@ -364,6 +365,7 @@ function imageShortcode(src, cls, alt, sizes, widths) {
     class: cls,
     alt,
     sizes,
+    src,
     loading: "lazy",
     decoding: "async",
   };


### PR DESCRIPTION
In the current version the output e.g. for missing `alt` attribute contains an "undefined" as the image path, because the example doesn't provide that attribute to generateHTML.

This change adds the `src` attribute to imageAttributes (like generateHTML expects), so the error messages are more meaningful.