### PR TITLE
[feat] Added accessible heading anchors

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -360,6 +360,17 @@ ${text.trim()}
 	mdIt.linkify.tlds('.io', false);
 	eleventyConfig.setLibrary("md", mdIt);
 
+	eleventyConfig.addTransform('labelledAnchor', (content, outputPath) => {
+		const posts = /index\.html/i;
+		const anchors = /<a class="direct-link" href="#(.*?)">#<\/a>/ig;
+		if (outputPath && outputPath.match(posts)) {
+			content = content.replace(anchors, (_, p1) => (
+				`<a class="direct-link" href="#${p1}" aria-labelledby="${p1}">#</a>`
+			));
+		}
+		return content;
+	})
+
 	eleventyConfig.addFilter("newsDate", (dateObj, format = "yyyy LLLL dd") => {
 		if(typeof dateObj === "string") {
 			return DateTime.fromISO(dateObj).toFormat(format);

--- a/_includes/index.css
+++ b/_includes/index.css
@@ -567,7 +567,7 @@ footer.elv-layout {
 a[href].direct-link,
 a[href].direct-link:visited {
 	color: #949494;
-	visibility: hidden;
+	opacity: 0;
 }
 a[href].direct-link:focus,
 a[href].direct-link:focus:visited,
@@ -575,7 +575,7 @@ a[href].direct-link:focus:visited,
 :hover > a[href].direct-link:visited,
 :focus > a[href].direct-link,
 :focus > a[href].direct-link:visited {
-	visibility: visible;
+	opacity: 1;
 }
 /* don’t use a direct link, should be a link to the page */
 main .elv-toc + h1 .direct-link {


### PR DESCRIPTION
On #222 

It seems like there are two options for heading anchors here:<br> **a)** add modified `renderPermalink` function to the `markdownItAnchor` opts object ([link](https://github.com/valeriangalliat/markdown-it-anchor/blob/master/index.js#L13)) <br>**b)** or use `eleventyConfig.addTransform`, which I've done.

