### PR TITLE
Clarify that page.outputPath and page.url can sometimes be `false`, not strings

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -450,7 +450,7 @@ const htmlmin = require("html-minifier");
 module.exports = function(eleventyConfig) {
   eleventyConfig.addTransform("htmlmin", function(content, outputPath) {
     // Eleventy 1.0+: use this.inputPath and this.outputPath instead
-    if( outputPath.endsWith(".html") ) {
+    if( outputPath && outputPath.endsWith(".html") ) {
       let minified = htmlmin.minify(content, {
         useShortDoctype: true,
         removeComments: true,

--- a/docs/data-eleventy-supplied.md
+++ b/docs/data-eleventy-supplied.md
@@ -19,25 +19,27 @@ Here are a few data values we supply to your page that you can use in your templ
 
 ```js
 let page = {
-  
+
   // URL can be used in <a href> to link to other templates
+  // Note: This value will be `false` if `permalink` is set to `false`.
   url: "/current/page/myFile/",
-  
+
   // For permalinks: inputPath filename minus template file extension (New in v0.3.4)
   fileSlug: "myFile",
 
   // For permalinks: inputPath minus template file extension (New in v0.9.0)
   filePathStem: "/current/page/myFile",
-  
+
   // JS Date Object for current page (used to sort collections)
   date: new Date(),
-  
+
   // The path to the original source file for the template
   // Note: this will include your input directory path!
   inputPath: "./current/page/myFile.md",
-  
+
   // Depends on your output directory (the default is _site)
   // You probably won’t use this: `url` is better.
+    // Note: This value will be `false` if `permalink` is set to `false`.
   outputPath: "./_site/current/page/myFile/index.html"
 };
 ```

--- a/docs/data-eleventy-supplied.md
+++ b/docs/data-eleventy-supplied.md
@@ -39,7 +39,7 @@ let page = {
 
   // Depends on your output directory (the default is _site)
   // You probably won’t use this: `url` is better.
-    // Note: This value will be `false` if `permalink` is set to `false`.
+  // Note: This value will be `false` if `permalink` is set to `false`.
   outputPath: "./_site/current/page/myFile/index.html"
 };
 ```

--- a/docs/permalinks.md
+++ b/docs/permalinks.md
@@ -119,7 +119,7 @@ Both of the above examples will write to `_site/this-is-a-new-path/subdirectory/
 
 ### `permalink: false`
 
-If you set the `permalink` value to be `false`, this will disable writing the file to disk in your output folder. The file will still be processed normally (and present in collections) but will not be available in your output directory as a standalone template.
+If you set the `permalink` value to be `false`, this will disable writing the file to disk in your output folder. The file will still be processed normally (and present in collections, with its [`url` and `outputPath` properties](/docs/data-eleventy-supplied.md) set to `false`) but will not be available in your output directory as a standalone template.
 
 {% codetitle "YAML Front Matter", "Syntax" %}
 


### PR DESCRIPTION
## What

The `page.outputPath` and `page.url` attributes are usually strings, but when a file has `permalink: false` set, these values will be the boolean `false`. This PR:

* points this out in the section on Eleventy-supplied data (the main place where `outputPath` and `url` seem to be documented)
* points this out in the section describing `permalink: false`
* fixes a code example (a transform using html-minifier) which previously assumed that `outputPath` was always a string, and hence would error if any file had `permalink: false`

## Why

This is intended to address https://github.com/11ty/eleventy/issues/653. It seems like this error has been encountered multiple times by plugin developers, as well as by people who have used the html-minifier example from the docs. There has been some discussion on that issue about whether the API should be changed (e.g. returning an empty string instead of `false`), but my impression is that the fundamental problem is just that this behaviour is not clearly documented (and actively not handled by a code example in the docs), hence this PR.