### PR TITLE
Fix a typo in the Liquid `reverse` example

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -219,7 +219,7 @@ And in Liquid it’d look like this:
 {% raw %}
 ```html
 <ul>
-{%- for post in collections.post reverse -%}
+{%- for post in collections.post reversed -%}
   <li>{{ post.data.title }}</li>
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
Using the `reverse` filter with Liquid to reverse a collections order as shown here results in a compile error. 
According to this [thread](https://github.com/11ty/eleventy/issues/194#:~:text=Using%20Liquid%E2%80%99s-,reversed,-filter%20on%20the), the correct filter should `reversed`. 
Using this filter, reverses the collection as intended.