### PR TITLE
Fix reference to `src` param in Docs Image plugin Synchronous example

### DIFF
--- a/docs/plugins/image.md
+++ b/docs/plugins/image.md
@@ -368,7 +368,7 @@ function imageShortcode(src, cls, alt, sizes, widths) {
     decoding: "async",
   };
   // get metadata even the images are not fully generated
-  metadata = Image.statsSync(source, options);
+  metadata = Image.statsSync(src, options);
   return Image.generateHTML(metadata, imageAttributes);
 }
 


### PR DESCRIPTION
Fixes a typo in the Synchronous sample code for the Image plugin.