### PR TITLE
Add warning about using npx without @11ty

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,8 @@ If you’re using a global install of Eleventy, remove `npx @11ty/` from the beg
 eleventy
 ```
 
+<div class="elv-callout elv-callout-warn"><strong>Warning:</strong> Using just <code>npx eleventy</code> may seem to work, but could result in downloading and executing the wrong package if you don't have Eleventy installed locally or globally already. Be sure to prefix your <code>npx</code> calls with <code>@11ty/</code>.</div>
+
 ```bash
 # `npx @11ty/eleventy` is the same as:
 npx @11ty/eleventy --input=. --output=_site


### PR DESCRIPTION
<img width="1032" alt="a screenshot of the 11ty docs website on the Command Line Usage page, with the text from this PR added in a yellow-backgrounded callout section" src="https://user-images.githubusercontent.com/4480480/113731803-acae7880-96be-11eb-8355-c9f02860b179.png">

Closes #1013 