### PR TITLE
Typo for `source.sourceType`

### DIFF
--- a/netlify/functions/image.js
+++ b/netlify/functions/image.js
@@ -44,7 +44,7 @@ async function handler(event, context) {
     return {
       statusCode: 200,
       headers: {
-        "content-type": source.soucceType
+        "content-type": source.sourceType
       },
       body: source.buffer.toString('base64'),
       isBase64Encoded: true


### PR DESCRIPTION
Feel free to fix this outside this PR - just thought this was an interesting way to show you the typo