### PR TITLE
Fix typo in descending sort order example

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -261,7 +261,7 @@ And in Liquid it’d look like this:
 {% raw %}
 ```html
 <ul>
-{%- for post in collections.post reverse -%}
+{%- for post in collections.post reversed -%}
   <li>{{ post.data.title }}</li>
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
looks like in liquid the[ correct parameter to reverse sort on a for loop](http://shopify.github.io/liquid/tags/iteration/#reversed) is reverse**d**, not reverse. Added the errant D.