### PR TITLE
docs: add JS template example to quick tip #1

### DIFF
--- a/src/docs/quicktips/inline-css.md
+++ b/src/docs/quicktips/inline-css.md
@@ -54,6 +54,22 @@ Capture the CSS into a variable and run it through the filter (this sample is us
 ```
 {% endraw %}
 
+## Using JavaScript templates
+
+You can also inline minified CSS in a [JavaScript template](/docs/languages/javascript/). This technique does not use filters, and instead uses `async` functions:
+
+```js
+const fs = require("fs/promises");
+const path = require("path");
+const CleanCSS = require("clean-css");
+
+module.exports = async () => `<style>
+  ${await fs
+    .readFile(path.resolve(__dirname, "./sample.css"))
+    .then((data) => new CleanCSS().minify(data).styles)}
+</style>`
+```
+
 ### Warning about Content Security Policy
 
 {% callout "warn" %}


### PR DESCRIPTION
Hey there. This PR adds an a JS template example to Quick Tip 1. It wasn't immediately clear to me how to do it, hence the PR. But no worries if you don't want it.

Thanks for 11ty!