### PR TITLE
Adds Nordhealth.com and Nordhealth.design to examples

### DIFF
--- a/src/_data/sites/nord-design-system.json
+++ b/src/_data/sites/nord-design-system.json
@@ -1,0 +1,7 @@
+{
+  "name": "Nord Design System",
+  "url": "https://nordhealth.design/",
+  "description": "Nord Design System provides a set of organized tools, resources, and guidelines that work as the foundation for Nordhealth’s products.",
+  "twitter": "nordhealthhq",
+  "authoredBy": ["viljamis"]
+}

--- a/src/_data/sites/nordhealth.json
+++ b/src/_data/sites/nordhealth.json
@@ -1,0 +1,7 @@
+{
+  "name": "Nordhealth",
+  "url": "https://nordhealth.com/",
+  "description": "Nordhealth is on a mission to redefine digital healthcare.",
+  "twitter": "nordhealthhq",
+  "authoredBy": ["viljamis"]
+}


### PR DESCRIPTION
This pull request adds these two Eleventy websites to examples:

- https://nordhealth.design/
- https://nordhealth.com/