### PR TITLE
Add the note about a multiple word tag

### DIFF
--- a/src/docs/collections.md
+++ b/src/docs/collections.md
@@ -146,6 +146,16 @@ tags: cat
 
 This content would show up in the template data inside of `collections.cat`.
 
+### A multiple words tag: cat and dog
+
+```markdown
+---
+tags: cat and dog
+---
+```
+
+If you use multiple words for one tag you can access the content by the following syntax `collections['cat and dog']`.
+
 ### Multiple tags, single line
 
 ```markdown

--- a/src/docs/collections.md
+++ b/src/docs/collections.md
@@ -146,7 +146,7 @@ tags: cat
 
 This content would show up in the template data inside of `collections.cat`.
 
-### A multiple words tag: cat and dog
+### Using multiple words in a single tag
 
 ```markdown
 ---


### PR DESCRIPTION
From my point of view, it is worth adding the note about using a
multiple word tag.

It would be extremely useful for newcomers who play with the official
starter project. That project contains a lot of multiple word tags and
looking at the current doc page it's not clear how to manage a post with
a tag like `number 2` or `second tag`.