### PR TITLE
Update js-yaml usage: no safeLoad in v4; use load

### DIFF
--- a/src/docs/data-custom.md
+++ b/src/docs/data-custom.md
@@ -28,7 +28,7 @@ Here we’re using the [`js-yaml` package](https://www.npmjs.com/package/js-yaml
 const yaml = require("js-yaml");
 
 module.exports = eleventyConfig => {
-  eleventyConfig.addDataExtension("yaml", contents => yaml.safeLoad(contents));
+  eleventyConfig.addDataExtension("yaml", contents => yaml.load(contents));
 };
 ```
 
@@ -74,7 +74,7 @@ module.exports = eleventyConfig => {
   eleventyConfig.addDataExtension("toml", contents => toml.parse(contents));
 
   // Higher priority
-  eleventyConfig.addDataExtension("yaml", contents => yaml.safeLoad(contents));
+  eleventyConfig.addDataExtension("yaml", contents => yaml.load(contents));
 };
 ```
 


### PR DESCRIPTION
Using the previous sample code resulted in:

```
`TemplateDataParseError` was thrown
> Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.

`Error` was thrown:
    Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
        at Object.safeLoad (/Users/edbrannin/dev/misc/mercy/node_modules/js-yaml/index.js:10:11)
        at /Users/edbrannin/dev/misc/mercy/.eleventy.js:4:60
        at TemplateData._parseDataFile (/Users/edbrannin/dev/misc/mercy/node_modules/@11ty/eleventy/src/TemplateData.js:351:16)
        at async TemplateData.getAllGlobalData (/Users/edbrannin/dev/misc/mercy/node_modules/@11ty/eleventy/src/TemplateData.js:228:18)
        at async TemplateData.getData (/Users/edbrannin/dev/misc/mercy/node_modules/@11ty/eleventy/src/TemplateData.js:255:24)
error Command failed with exit code 1.
```