### PR TITLE
adding note about 'alias: page'

### DIFF
--- a/src/docs/pages-from-data.md
+++ b/src/docs/pages-from-data.md
@@ -53,6 +53,8 @@ permalink: "possums/{{ possum.name | slug }}/"
 
 This template will generate four files, one for each possum, where the filename is based on the possum's name passed through the `slug` function. As possums are added and edited the resultant possum details page will be updated automatically.
 
+{% callout "info" %}Note that {% raw %}<code>page</code>{% endraw %} is a reserved word so you cannot use {% raw %}<code>alias: page</code>{% endraw %}.{% endcallout %}
+
 ## Related Pagination Topics:
 
 * [Pagination: Paging an Object](/docs/pagination/#paging-an-object)

--- a/src/docs/pages-from-data.md
+++ b/src/docs/pages-from-data.md
@@ -53,7 +53,7 @@ permalink: "possums/{{ possum.name | slug }}/"
 
 This template will generate four files, one for each possum, where the filename is based on the possum's name passed through the `slug` function. As possums are added and edited the resultant possum details page will be updated automatically.
 
-{% callout "info" %}Note that {% raw %}<code>page</code>{% endraw %} is a reserved word so you cannot use {% raw %}<code>alias: page</code>{% endraw %}.{% endcallout %}
+{% callout "info" %}Note that <code>page</code> is a reserved word so you cannot use <code>alias: page</code>. Read about Eleventy’s reserved data names in <a href="/docs/data-eleventy-supplied">Eleventy Supplied Data</a>.{% endcallout %}
 
 ## Related Pagination Topics:
 

--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -299,6 +299,8 @@ You can use the alias in your content too {{ wonder }}.
 
 This writes to `_site/different/item1/index.html` and `_site/different/item2/index.html`.
 
+{% callout "info" %}Note that {% raw %}<code>page</code>{% endraw %} is a reserved word so you cannot use {% raw %}<code>alias: page</code>{% endraw %}.{% endcallout %}
+
 If your chunk `size` is greater than 1, the alias will be an array instead of a single value.
 
 {% codetitle "Liquid, Nunjucks", "Syntax" %}

--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -299,7 +299,7 @@ You can use the alias in your content too {{ wonder }}.
 
 This writes to `_site/different/item1/index.html` and `_site/different/item2/index.html`.
 
-{% callout "info" %}Note that {% raw %}<code>page</code>{% endraw %} is a reserved word so you cannot use {% raw %}<code>alias: page</code>{% endraw %}.{% endcallout %}
+{% callout "info" %}Note that <code>page</code> is a reserved word so you cannot use <code>alias: page</code>. Read about Eleventy’s reserved data names in <a href="/docs/data-eleventy-supplied">Eleventy Supplied Data</a>.{% endcallout %}
 
 If your chunk `size` is greater than 1, the alias will be an array instead of a single value.
 


### PR DESCRIPTION
This PR is related to this issue I created on the `11ty/eleventy` repo https://github.com/11ty/eleventy/issues/1794

I was trying to paginate through `pages` so my first inclination was to alias each entry as `page` (`alias: page`)

Apparently, `page` is a reserved word in this context and I got a very cryptic error which didn't seem intuitively related in any way to the alias name:
```
> mapB.date.getTime is not a function

`TypeError` was thrown:
    TypeError: mapB.date.getTime is not a function
 ```
 
 If there are any other reserved words (in addition to `page`) then it would be good to call those out as well.

Other (probably better) alternatives to this PR:
- support `alias: page` without throwing an error
- throw a more specific error message

(until one of those can be implemented, I think at least calling it out in the docs would be helpful)