### PR TITLE
Add definitions for @fortawesome plugins

### DIFF
--- a/src/_data/plugins/eleventy-plugin-fortawesome-brands-shortcode.json
+++ b/src/_data/plugins/eleventy-plugin-fortawesome-brands-shortcode.json
@@ -1,0 +1,4 @@
+{
+	"npm": "@vidhill/fortawesome-brands-11ty-shortcode",
+	"description": "Shortcode, allows @fortawesome/free-brands-svg-icons to be embedded as inline svg into templates."
+}

--- a/src/_data/plugins/eleventy-plugin-fortawesome-regular-shortcode.json
+++ b/src/_data/plugins/eleventy-plugin-fortawesome-regular-shortcode.json
@@ -1,0 +1,4 @@
+{
+	"npm": "@vidhill/fortawesome-free-regular-11ty-shortcode",
+	"description": "Shortcode, allows @fortawesome/free-regular-svg-icons to be embedded as inline svg into templates."
+}


### PR DESCRIPTION
I recently created these plugins and/or shortcodes (can be used as a plugin or as shortcode definitions) 

They can be used to embed svgs from @fortawesome into templates