### PR TITLE
Create eleventy-plugin-ids.json

### DIFF
--- a/src/_data/plugins/eleventy-plugin-ids.json
+++ b/src/_data/plugins/eleventy-plugin-ids.json
@@ -1,0 +1,5 @@
+{
+	"npm": "@orchidjs/eleventy-plugin-ids",
+	"author": "oyejorge",
+	"description": "Add ids to html headings and other elements"
+}


### PR DESCRIPTION
Simple plugin for generating/adding ids for headers and other elements as a possible solution for [this issue](https://github.com/11ty/eleventy/issues/1593).

```html
<h1>Foo Bar</h1>
```
becomes
```html
<h1 id="foo-bar">Foo Bar</h1>
```