### PR TITLE
Update installation instructions to save to devDependencies

### DIFF
--- a/src/docs/plugins/image.md
+++ b/src/docs/plugins/image.md
@@ -37,7 +37,7 @@ You maintain full control of your HTML—this plugin does not generate any marku
 * [`eleventy-img` on npm](https://www.npmjs.com/package/@11ty/eleventy-img)
 
 ```
-npm install -D @11ty/eleventy-img
+npm install --save-dev @11ty/eleventy-img
 ```
 
 ## Usage

--- a/src/docs/plugins/image.md
+++ b/src/docs/plugins/image.md
@@ -37,7 +37,7 @@ You maintain full control of your HTML—this plugin does not generate any marku
 * [`eleventy-img` on npm](https://www.npmjs.com/package/@11ty/eleventy-img)
 
 ```
-npm install @11ty/eleventy-img
+npm install -D @11ty/eleventy-img
 ```
 
 ## Usage


### PR DESCRIPTION
Since this is a package used during development, and is not a package containing files that get published, it should be a dev dependency.

Related PR: https://github.com/11ty/eleventy-img/pull/109