### PR TITLE
Fix anchor to `pre-rendered templates` in overview section

### DIFF
--- a/src/docs/overview.md
+++ b/src/docs/overview.md
@@ -15,7 +15,7 @@ Eleventy **works with multiple template languages**. You can pick one or use the
 
 {% templatelangs templatetypes, page %}
 
-Eleventy is **not a JavaScript framework**—that means *zero boilerplate client-side JavaScript*. We’re thinking long term and opting out of the framework rat race. The tool chain, code conventions, and modules you use in your front end stack are decoupled from this tool. Work from a solid foundation of <a href="/docs/resources/#theyre-not-server-side-rendered-theyre-pre-rendered" class="buzzword">pre-rendered templates</a> that suit your project’s <a href="/docs/resources/#progressive-enhancement" class="buzzword">progressive enhancement</a> baseline requirements.
+Eleventy is **not a JavaScript framework**—that means *zero boilerplate client-side JavaScript*. We’re thinking long term and opting out of the framework rat race. The tool chain, code conventions, and modules you use in your front end stack are decoupled from this tool. Work from a solid foundation of <a href="/docs/resources/#pre-rendered-templates-by-default" class="buzzword">pre-rendered templates</a> that suit your project’s <a href="/docs/resources/#progressive-enhancement" class="buzzword">progressive enhancement</a> baseline requirements.
 
 Eleventy is **incremental**. You don’t need to start an Eleventy project from scratch. Eleventy is flexible enough to allow conversion of only a few templates at a time. Migrate as fast or as slow as you’d like.
 


### PR DESCRIPTION
Fixes #1101