### PR TITLE
Add eleventy-plugin-img2picture

### DIFF
--- a/src/_data/plugins/eleventy-plugin-img2picture.json
+++ b/src/_data/plugins/eleventy-plugin-img2picture.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-img2picture",
+	"author": "saneef",
+	"description": "replaces <img> using <picture> with resized and optimized images."
+}


### PR DESCRIPTION
Plugin to replace `<img>` using `<picture>` with resized and optimized images. The plugin uses transform API to replace `<img>` tags. So, no need of shortcodes!