### PR TITLE
Add link to log filter on debugging page

### DIFF
--- a/src/docs/debugging.md
+++ b/src/docs/debugging.md
@@ -59,3 +59,7 @@ The commands above limit the messages from `debug` to Eleventy specific things w
 ### Analyze Performance
 
 {% addedin "0.11.0" %} Read more about how to [use `debug` to analyze the performance of your Eleventy build](/docs/debug-performance/).
+
+## Debug individual variables
+
+{% addedin "0.11.0" %} In addition to using `debug`, you can use the global filter [`log`](/docs/filters/log) to `console.log` anything from inside a template file.


### PR DESCRIPTION
`log` is cool; people might want to know about it when they're wondering how to debug their eleventy pages. So this PR adds a note on the debugging docs page about `log` and points back to the main page for `log`.