### PR TITLE
Add sample usage for Nunjucks filters with multiple parameters

### DIFF
--- a/src/docs/languages/nunjucks.md
+++ b/src/docs/languages/nunjucks.md
@@ -77,6 +77,23 @@ module.exports = function(eleventyConfig) {
 ```
 {% endraw %}
 
+### Multiple Filter Arguments
+
+```js
+module.exports = function(eleventyConfig) {
+  // Nunjucks Filter
+  eleventyConfig.addNunjucksFilter("concatThreeStrings", function(arg1, arg2, arg3) {
+    return arg1 + arg2 + arg3;
+  });
+};
+```
+
+{% raw %}
+```html
+<h1>{{ "first" | concatThreeThings("second", "third") }}</h1>
+```
+{% endraw %}
+
 ### Asynchronous Nunjucks Filters {% addedin "0.2.13" %}
 
 By default, almost all templating engines are synchronous. Nunjucks supports some asynchronous behavior, like filters. Here’s how that works:


### PR DESCRIPTION
### Notes
- Adds sample usage for Nunjucks filters with multiple parameters. Example is based heavily on a [similar example](https://www.11ty.dev/docs/languages/liquid/#multiple-filter-arguments) in the Liquid doc page.
- Closes https://github.com/11ty/eleventy/issues/1244