### PR TITLE
Suggested change to collections reverse pitfall

### DIFF
--- a/src/_includes/components/callout.css
+++ b/src/_includes/components/callout.css
@@ -31,6 +31,11 @@ table .elv-callout {
 .elv-callout-info:before {
 	content: "ℹ️ ";
 }
+.elv-callout pre {
+	background-color: transparent;
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
 .elv-callout code {
 	background-color: hsl(195, 100%, 80%);
 }

--- a/src/docs/collections.md
+++ b/src/docs/collections.md
@@ -280,6 +280,18 @@ exports.render = function(data) {
 <div class="elv-callout elv-callout-warn elv-callout-warn-block" id="array-reverse">
   <p>You should <em><strong>not</strong></em> use Array <code>reverse()</code> on collection arrays in your templates, like so:</p>
   <p><code>{%raw %}{%- for post in collections.post.reverse() -%}{% endraw %}</code></p>
+  <p>Nor should you use it in custom shortcodes, like this:</p>
+  {%raw %}
+  ```js
+  eleventyConfig.addShortcode(
+		"aPostList",
+		function (aCollection){
+      aCollection.reverse()
+      ...
+    }
+  )
+  ```
+  {% endraw %}
   <p>This will <a href="https://doesitmutate.xyz/reverse/">mutate the array</a> and re-order it <em>in-place</em> and will have side effects for any use of that collection in other templates.</p>
   <p>Instead, use one of the many template engine utilities provided for you to do this, such as <a href="http://shopify.github.io/liquid/filters/reverse/">Liquid’s <code>reverse</code></a> or <a href="https://mozilla.github.io/nunjucks/templating.html#reverse">Nunjucks’ <code>reverse</code></a></p>
   <p>This is a <a href="/docs/pitfalls/"><strong>Common Pitfall</strong></a>.</p>


### PR DESCRIPTION
Passing collections into shortcodes also has this issue of mutating the collections object, but that is not clear in the documentation. I'm suggesting adding that case to the documented pitfalls around using `reverse`.