### PR TITLE
Add metagendocs.netlify.app to site list

### DIFF
--- a/src/_data/sites/metagen-docs.json
+++ b/src/_data/sites/metagen-docs.json
@@ -1,0 +1,7 @@
+{
+    "name": "Metagen Docs",
+    "url": "https://metagendocs.netlify.app",
+    "description": "Documentation site for the 11ty plugin eleventy-plugin-metagen.",
+    "twitter": "tannerdolby",
+    "source_url": "https://github.com/tannerdolby/metagen-docs"
+}


### PR DESCRIPTION
Adds https://metagendocs.netlify.app to list of sites.

