### PR TITLE
Add note on computed data to frontmatter doc page

### DIFF
--- a/src/docs/data-frontmatter.md
+++ b/src/docs/data-frontmatter.md
@@ -23,6 +23,8 @@ The above is using [YAML syntax](https://learnxinyminutes.com/docs/yaml/). You c
 
 Locally assigned front matter values override things further up the layout chain. Note also that layouts can contain front matter variables that you can use in your local template. Leaf template front matter takes precedence over layout front matter. Read more about [Layouts](/docs/layouts/).
 
+Note that only the [`permalink`](/docs/permalinks/) and [`eleventyComputed`](/docs/data-computed) front matter values can contain variables and shortcodes like you would use in the body of your templates. If you need to use variables or shortcodes in other front matter values, use `eleventyComputed` to set them. 
+
 ## Template Configuration
 <span id="user-defined-front-matter-customizations"></span>
 


### PR DESCRIPTION
This is something I've seen trip people up in the discord a few times now - they want to use shortcodes or variables in front matter, but aren't sure how. 

So, this PR adds a note to the docs on frontmatter that there is a way to do this, and points to the documentation on how. 