### PR TITLE
Update author name in eleventy-plugin-svg-sprite.json

### DIFF
--- a/src/_data/plugins/eleventy-plugin-svg-sprite.json
+++ b/src/_data/plugins/eleventy-plugin-svg-sprite.json
@@ -1,5 +1,5 @@
 {
 	"npm": "eleventy-plugin-svg-sprite",
-	"author": "patrickxchong",
+	"author": "Patrick153",
 	"description": "will compile a directory of SVG files into a single SVG sprite and install shortcodes to embed SVG sprite and SVG content"
 }


### PR DESCRIPTION
The plugin currently doesn't show up on my author page as it is under my twitter username https://www.11ty.dev/authors/patrick153/ (which is sadly different from my github username which I prefer)