### PR TITLE
SEO - Prevent keyword cannibalization

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -16,7 +16,7 @@ eleventyComputed:
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		{%- set subtitle %}{{ newstitle or searchTitle or relatedTitle or tiptitle or eleventyNavigation.key or title }}{% endset %}
-		{%- set subtitleText %}{% if subtitle and subtitle != "Eleventy Home" %}{{ subtitle }}—{% endif %}Eleventy, a simpler static site generator.{% endset %}
+		{%- set subtitleText %}{{ subtitle }}{% if subtitle and subtitle != "Eleventy, a simpler static site generator" %} — Eleventy{% endif %}{% endset %}
 		<title>{{ subtitleText }}</title>
 		<meta name="description" content="{{ subtitleText }}">
 		<link rel="icon" type="image/png" sizes="96x96" href="/img/favicon.png">

--- a/src/index.md
+++ b/src/index.md
@@ -5,7 +5,7 @@ logoContent: "<span class='elv-hero-content'>1.0</span>"
 ignoreGitHubButtons: true
 ignoreSupporters: true
 ignoreFastestSite: true
-searchTitle: Eleventy Home
+searchTitle: Eleventy, a simpler static site generator
 excludeFromSearch: true
 bigPossum: true
 permalink:


### PR DESCRIPTION
Regarding the search "static site generator", the 11ty website suffers from [keyword cannibalization](https://yoast.com/keyword-cannibalization/). This is due to the repetition of the sequence "a simpler static site generator" in all titles. It is as if all pages were shouting at Google "I'm the right page regarding static site generator, please pick me!!!"

This PR implements a classic SEO rule:
- Home page: "{brand name} {tagline}" : "Eleventy, a simpler static site generator"
- Other pages: "{title} {brand name}". For example: "Overview - Eleventy"

Expected improvements:
- Better ranking for the search "static site generator" (currently, ~15 position / 2nd page)
- [Prevent Google from rewriting the titles](https://developers.google.com/search/blog/2021/08/update-to-generating-page-titles), for example:
![Why this title?](https://user-images.githubusercontent.com/423852/140285470-3ba31c00-d7ba-4f78-9014-0151a5335a1d.png)

This PR is probably a bit particular. Feel free to discuss it if you wanna make sure it's correct.