### PR TITLE
Start off custom template languages doc

### DIFF
--- a/src/docs/languages/custom.md
+++ b/src/docs/languages/custom.md
@@ -9,5 +9,50 @@ layout: layouts/langs.njk
 ---
 {% addedin "1.0.0" %}
 
-* [Read more](https://github.com/11ty/eleventy/issues/117)
-* [Documentation pending](https://github.com/11ty/eleventy/issues/2036)
+{% callout %}This documentation is incomplete! See [the issue proposing this feature](https://github.com/11ty/eleventy/issues/117) and [the issue for complete documentation.](https://github.com/11ty/eleventy/issues/2036){% endcallout %}
+
+To create a custom template language, call `eleventyConfig.addExtension`:
+
+```js
+eleventyConfig.addExtension("mdx", {
+  // the file extension that the compiled output will get
+  outputFileExtension: "html",
+
+  // create a compiler for the provided file.
+  // optional if you provide an extension Eleventy already supports for the `extension` parameter above.
+  async compile(content, inputPath) {
+    // this.config is your eleventyConfig object
+
+    return function (data) {
+      // data is the merged data object to pass to the template.
+      // this.defaultRenderer is the default renderer for the file type, if there is one
+      return "<html>...</html>"
+    }
+  },
+
+  // [optional] called before this template language is first used
+  init() {
+    // this.config is your eleventyConfig object
+  },
+
+  // [optional] provide data for your file (such as from front matter):
+  // either specify a function that returns the data directly...
+  async getData(inputPath) { /* ... */ },
+  // or, specify a list of data keys, and `getInstanceFromInputPath`:
+  getData: true, // equivalent to ["data"]
+  getData: ["key1", "key2", "key3"], // only the keys you specify will be available to the template
+  async getInstanceFromInputPath(inputPath) {
+    return {
+      // ... return data here. Values can be either the value itself, a promise, or a function that returns either of those.
+
+      // optional, overrides the value of `getData`:
+      // (must be an array or other iterable if present)
+      eleventyDataKey: ["key1", "key2", "key3"]
+    }
+  }
+  
+  // [optional] disable reading from the file (resulting in a `null` value for `content` in the `compile` method)
+  // (you might do this if the template engine you’re providing handles reading files itself)
+  read: false
+})
+```

--- a/src/docs/languages/custom.md
+++ b/src/docs/languages/custom.md
@@ -9,7 +9,11 @@ layout: layouts/langs.njk
 ---
 {% addedin "1.0.0" %}
 
-{% callout %}This documentation is incomplete! See [the issue proposing this feature](https://github.com/11ty/eleventy/issues/117) and [the issue for complete documentation.](https://github.com/11ty/eleventy/issues/2036){% endcallout %}
+{% callout %}
+
+This documentation is incomplete! See [the issue proposing this feature](https://github.com/11ty/eleventy/issues/117) and [the issue for complete documentation.](https://github.com/11ty/eleventy/issues/2036)
+
+{% endcallout %}
 
 To create a custom template language, call `eleventyConfig.addExtension`:
 

--- a/src/docs/languages/custom.md
+++ b/src/docs/languages/custom.md
@@ -56,3 +56,5 @@ eleventyConfig.addExtension("mdx", {
   read: false
 })
 ```
+
+For more details on how all of this works, consider exploring the source code ([`Engines/Custom.js`](https://github.com/11ty/eleventy/blob/d4a7d67b6b82ccf0e5a77c1a3530f09a9b5fef65/src/Engines/Custom.js) is a good starting point)


### PR DESCRIPTION
This works toward addressing https://github.com/11ty/eleventy/issues/2036.

Yesterday, I spent some time trying to implement a custom template language. I ended up having to read the source and do some debugging to figure out how to get it working. This PR contains the results of my findings, so hopefully people will be able to reference this until a more complete doc page can be written.

As I am new to Eleventy, I’m not confident that all of this is correct, and would appreciate any feedback you have!

Preview: https://deploy-preview-1240--11ty.netlify.app/docs/languages/custom/