### PR TITLE
Add new plugin: @pcdevil/eleventy-plugin-intl-utils

### DIFF
--- a/src/_data/plugins/eleventy-plugin-intl-utils.json
+++ b/src/_data/plugins/eleventy-plugin-intl-utils.json
@@ -1,0 +1,5 @@
+{
+	"npm": "@pcdevil/eleventy-plugin-intl-utils",
+	"author": "pcdevil",
+	"description": "a set of internationalization utils"
+}


### PR DESCRIPTION
Add a new plugin to use [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) global object more conveniently in Eleventy for some use-cases.

Links:
- [repository](https://github.com/pcdevil/eleventy-plugin-intl-utils)
- [npm](https://www.npmjs.com/package/@pcdevil/eleventy-plugin-intl-utils)
