### PR TITLE
Remove full stop from heading

### DIFF
--- a/src/docs/languages/custom.md
+++ b/src/docs/languages/custom.md
@@ -121,7 +121,7 @@ module.exports = function(eleventyConfig) {
 };
 ```
 
-## Skipping a template from inside of the `compile` function.
+## Skipping a template from inside of the `compile` function
 
 To add support for Sass’ underscore convention (file names that start with an underscore aren’t written to the output directory), just return early in the `compile` function (don’t return a `render` function).
 


### PR DESCRIPTION
The full stop was being used in the heading id attribute as well as the heading, which causes anchor links to break in some contexts (i.e. Twitter)