### PR TITLE
Fix compile error in example code for custom template language

### DIFF
--- a/src/docs/languages/custom.md
+++ b/src/docs/languages/custom.md
@@ -164,7 +164,7 @@ module.exports = function(eleventyConfig) {
         return this.defaultRenderer(data);
       };
     }
-  }
+  });
 };
 ```
 


### PR DESCRIPTION
Example code wasn't closing its function call properly.