### PR TITLE
Expand glossary to include Eleventy-specific terms, and add definitions throughout the docs.

### DIFF
--- a/src/docs/filters.md
+++ b/src/docs/filters.md
@@ -14,7 +14,7 @@ tags:
 ---
 # Filters
 
-A filter is a function which can be used within templating syntax to transform data into a more presentable format. Filters are typically designed to be chained, so that the value returned from one filter is piped into the next filter.
+A <dfn>filter</dfn> is a function which can be used within templating syntax to transform data into a more presentable format. Filters are typically designed to be chained, so that the value returned from one filter is piped into the next filter.
 
 Various template engines can be extended with custom filters to modify content. Here are a few examples:
 

--- a/src/docs/filters.md
+++ b/src/docs/filters.md
@@ -14,6 +14,8 @@ tags:
 ---
 # Filters
 
+A filter is a function which can be used within templating syntax to transform data into a more presentable format. Filters are typically designed to be chained, so that the value returned from one filter is piped into the next filter.
+
 Various template engines can be extended with custom filters to modify content. Here are a few examples:
 
 

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -54,7 +54,7 @@ Make sure that you see `({% latestVersion versions, config %})` in your output. 
 
 ## <span class="numberflag"><span class="sr-only">Step</span> 4</span> Create some templates
 
-A <dfn>template</dfn> is a content file in [formats such as Markdown, HTML, Liquid, Nunjucks, and more](/docs/languages/) which Eleventy transforms into a page or pages.
+A <dfn>template</dfn> is a content file written in a [format such as Markdown, HTML, Liquid, Nunjucks, and more](/docs/languages/), which Eleventy transforms into a page (or pages) when building our site.
 
 Let’s run two commands to create two new template files.
 

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -54,6 +54,8 @@ Make sure that you see `({% latestVersion versions, config %})` in your output. 
 
 ## <span class="numberflag"><span class="sr-only">Step</span> 4</span> Create some templates
 
+A <dfn>template</dfn> is a content file in [formats such as Markdown, HTML, Liquid, Nunjucks, and more](/docs/languages) which Eleventy transforms into a page or pages.
+
 Let’s run two commands to create two new template files.
 
 {% codewithprompt "eleventysample", "all" %}

--- a/src/docs/getting-started.md
+++ b/src/docs/getting-started.md
@@ -54,7 +54,7 @@ Make sure that you see `({% latestVersion versions, config %})` in your output. 
 
 ## <span class="numberflag"><span class="sr-only">Step</span> 4</span> Create some templates
 
-A <dfn>template</dfn> is a content file in [formats such as Markdown, HTML, Liquid, Nunjucks, and more](/docs/languages) which Eleventy transforms into a page or pages.
+A <dfn>template</dfn> is a content file in [formats such as Markdown, HTML, Liquid, Nunjucks, and more](/docs/languages/) which Eleventy transforms into a page or pages.
 
 Let’s run two commands to create two new template files.
 

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -32,6 +32,12 @@ Eleventy's order of operations for evaluating all [data](#data) for any given [t
 
 [Read more about the data cascade.](/docs/data-cascade/)
 
+### Filter
+
+A function which can be used within templating syntax to transform data into a more presentable format. Filters are typically designed to be chained, so that the value returned from one filter is piped into the next filter.
+
+[Read more about filters.](/docs/filters/)
+
 ### Collection
 
 An array of [templates](#template), used to group similar content. Collections can be created by using [tags](/docs/collections/#tag-syntax) or by calling the [collections API in the Eleventy configuration](/docs/collections/#advanced-custom-filtering-and-sorting).

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -4,25 +4,51 @@ eleventyNavigation:
   key: Glossary
 ---
 
-# Glossary and Buzzwords
+# Glossary
+
+This page provides two lists of terms — one for [Eleventy-specific terminology](#eleventy-specific-terminology) that may be useful for when building out a project using Eleventy, and one for [industry jargon](#industry-terms-and-buzzwords) that may be useful for understanding context.
+
+_Work in progress: {% include "edit-on-github.njk" %}_
+
+## Eleventy-Specific Terminology
+
+### Template
+
+A content file written in a [format such as Markdown, HTML, Liquid, Nunjucks, and more](/docs/languages/), which Eleventy transforms into a page (or pages) in the built site. Templates can access [data](#data) exposed through the [data cascade](#data-cascade) with templating syntax.
+
+### Layout
+
+A template which wraps around another template, typically to provide the scaffolding markup for content to sit in.
+
+[Read more about using layouts.](/docs/layouts/)
+
+### Data
+
+Variables that can be used inside [templates](#template) and [layouts](#layout) using templating syntax. The data for a given template is aggregated through a process called the [data cascade](#data-cascade).
+
+### Data Cascade
+
+Eleventy's order of operations for evaluating all [data](#data) for any given [template](#template), and for resolving conflicts that arise. The data cascade follows the principle of colocation, so data defined broadly to apply to many templates will be overruled by data that targets the given template more specifically.
+
+[Read more about the data cascade.](/docs/data-cascade/)
+
+## Industry Terms and Buzzwords
 
 Bask in the warm glow of this _“Nobody ever got fired for buying IBM”_-style feel-good industry jargon.
 
 Our industry can be particularly bad about inventing words for things that already exist. Hopefully this page will help you navigate the labyrinth.
 
-_Work in progress: {% include "edit-on-github.njk" %}_
-
-## Static Sites
+### Static Sites
 
 A static site is a group of generated HTML files. Content is built into the HTML files rather than using a dynamic back end language to generate the content on-the-fly. A dynamic site can appear static when you add caching rules to make the content stickier. A static site can appear dynamic when you run your build quickly and often.
 
-## JAMstack
+### JAMstack
 
 > Modern web development architecture based on client-side JavaScript, reusable APIs, and prebuilt Markup.—[jamstack.org](https://jamstack.org/)
 
 Eleventy facilitates JAMstack sites—but you maintain full control over the JavaScript.
 
-## Progressive Enhancement
+### Progressive Enhancement
 
 <!-- You’re safe here. But a static site generator that is Progressive Enhancement friendly is only the beginning. -->
 
@@ -30,31 +56,31 @@ The idea that _content_ should be the priority for a website's development. In o
 
 As stated in the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement): "Special notice should be taken of accessibility. Acceptable alternatives should be provided where possible."
 
-## Data-Driven
+### Data-Driven
 
 Make components and markup data-driven so that you don’t have a bunch of one-off copy-pasted HTML instances littered throughout your project.
 
-## Serverless Friendly
+### Serverless Friendly
 
 > “You can take your front-end skills and do things that typically only a back-end can do. You can write a JavaScript function that you run and receive a response from by hitting a URL.”—[The Power of Serverless](https://serverless.css-tricks.com/) from [Chris Coyier](https://twitter.com/chriscoyier)
 
 Take care to make sure that <span class="buzzword">serverless</span> functions are <span class="buzzword">progressively enhanced</span>. If you call <span class="buzzword">serverless</span> functions in client-side JavaScript, they should be used for features that are outside the core functionality of the site. Use [Eleventy Serverless](/docs/plugins/serverless/) to generate pages on-request without any client-side JavaScript.
 
-## Lean Web
+### Lean Web
 
 To be honest it’s kind of a stretch to relate Lean methodology to this project but the term just kinda feels right.
 
-## Zero Config
+### Zero Config
 
 Zero config means that Eleventy can run without any command line parameters or configuration files.
 
 We’ve taken care to setup Eleventy so that that running the stock  `eleventy` command uses sensible defaults. Lower the barrier to entry for that first project build to get up and running faster.
 
-## Convention over Configuration Routing
+### Convention over Configuration Routing
 
 Can you believe that some frameworks require a centralized piece of configuration for routing? `eleventy` routes map the file system, unless you override with a `permalink`.
 
-## Pre-rendered Templates by Default
+### Pre-rendered Templates by Default
 
 With the rise of client side rendering of templates in JavaScript came significant performance problems, especially with users of less-capable (but none-the-less still modern) hardware. Did you know they’re selling new mobile devices that are pretty hardware-limited?
 
@@ -62,10 +88,10 @@ Many frameworks switched to Server Side Rendering, which meant running an applic
 
 Eleventy can also run in [Serverless mode](/docs/plugins/serverless/) for server side rendering _On Request_ or even _On Request Once and Cached for Subsequent Visitors_.
 
-## Hydration-less
+### Hydration-less
 
 Well, uh, we don’t inject or use any client-side JavaScript in Eleventy, so there’s nothing that needs hydration.
 
-## Apps not App Servers
+### Apps not App Servers
 
 Application servers can be slow. Instead of PHP, Java, or even Node.js dynamically generating page responses on the fly when the request comes in, have your pre-rendered templates ready to go for delivery! Maximum performance.

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -38,6 +38,12 @@ An array of [templates](#template), used to group similar content.
 
 [Read more about collections.](/docs/collections/)
 
+### Pagination
+
+A way to create pages by iterating over data.
+
+[Read more about pagination.](/docs/pagination/)
+
 ## Industry Terms and Buzzwords
 
 Bask in the warm glow of this _“Nobody ever got fired for buying IBM”_-style feel-good industry jargon.

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -32,6 +32,12 @@ Eleventy's order of operations for evaluating all [data](#data) for any given [t
 
 [Read more about the data cascade.](/docs/data-cascade/)
 
+### Collection
+
+An array of [templates](#template), used to group similar content.
+
+[Read more about collections.](/docs/collections/)
+
 ## Industry Terms and Buzzwords
 
 Bask in the warm glow of this _“Nobody ever got fired for buying IBM”_-style feel-good industry jargon.

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -44,6 +44,10 @@ A way to create pages by iterating over data.
 
 [Read more about pagination.](/docs/pagination/)
 
+### Plugin
+
+A portable, installable Eleventy configuration which can add [data](#data), [filters](#filter), [shortcodes](#shortcode), and more to a project's setup.
+
 ## Industry Terms and Buzzwords
 
 Bask in the warm glow of this _“Nobody ever got fired for buying IBM”_-style feel-good industry jargon.

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -50,6 +50,12 @@ A portable, installable Eleventy configuration which can add [data](#data), [fil
 
 [Read more about plugins.](/docs/plugins/)
 
+### Eleventy Serverless
+
+An opt-in build mode for Eleventy in which specified pages are built when a user requests them, rather than ahead of time during a build step. Optionally, pages that are built on request can be cached by the content delivery network to be used for future visits to that page.
+
+[Read more about Eleventy Serverless.](/docs/plugin/serverless/)
+
 ## Industry Terms and Buzzwords
 
 Bask in the warm glow of this _“Nobody ever got fired for buying IBM”_-style feel-good industry jargon.

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -34,9 +34,15 @@ Eleventy's order of operations for evaluating all [data](#data) for any given [t
 
 ### Filter
 
-A function which can be used within templating syntax to transform data into a more presentable format. Filters are typically designed to be chained, so that the value returned from one filter is piped into the next filter.
+A function which can be used within templating syntax to transform [data](#data) into a more presentable format. Filters are typically designed to be chained, so that the value returned from one filter is piped into the next filter.
 
 [Read more about filters.](/docs/filters/)
+
+### Shortcode
+
+A function which can be used within templating syntax to inject content into templates. Shortcodes can take many arguments, and can be thought of as a templating approach to reusable markup.
+
+[Read more about shortcodes.](/docs/shortcodes/)
 
 ### Collection
 

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -34,19 +34,21 @@ Eleventy's order of operations for evaluating all [data](#data) for any given [t
 
 ### Collection
 
-An array of [templates](#template), used to group similar content.
+An array of [templates](#template), used to group similar content. Collections can be created by using [tags](/docs/collections/#tag-syntax) or by calling the [collections API in the Eleventy configuration](/docs/collections/#advanced-custom-filtering-and-sorting).
 
 [Read more about collections.](/docs/collections/)
 
 ### Pagination
 
-A way to create pages by iterating over data.
+A way to create pages by iterating over data. The same template is applied to each chunk of the paginated data.
 
 [Read more about pagination.](/docs/pagination/)
 
 ### Plugin
 
 A portable, installable Eleventy configuration which can add [data](#data), [filters](#filter), [shortcodes](#shortcode), and more to a project's setup.
+
+[Read more about plugins.](/docs/plugins/)
 
 ## Industry Terms and Buzzwords
 


### PR DESCRIPTION
Howdy! I thought it might be useful to expand the glossary page to include more Eleventy-specific terminology for people working within Eleventy projects. Additionally, I've included a quick definition of "template" in the Getting Started page, since templates are Eleventy's bread and butter.

I'm super open to feedback — please let me know if there's anything I can change!