### PR TITLE
Fix complete pagination example for combined.11ty.js

### DIFF
--- a/src/_includes/examples/pagination/nav/combined.11ty.js
+++ b/src/_includes/examples/pagination/nav/combined.11ty.js
@@ -3,11 +3,11 @@ exports.render = function(data) {
   return `<nav aria-labelledby="my-pagination">
     <h2 id="my-pagination">This is my Pagination</h2>
     <ol>
-      <li>${data.page.url === data.pagination.href.first ? `<a href="${pagination.href.first}">First</a>` : `First`}</li>
+      <li>${data.page.url === data.pagination.href.first ? `<a href="${data.pagination.href.first}">First</a>` : `First`}</li>
       <li>${data.pagination.href.previous ? `<a href="${data.pagination.href.previous}">Previous</a>` : `Previous`}</li>
       ${data.pagination.pages.map(function (item, index) {
         return `<li><a href="${data.pagination.hrefs[index]}" ${data.pagination.hrefs[index] ? 'aria-current="page"' : "" }>Page ${index + 1}</a></li>`;
-      }).join("");}
+      }).join("")}
       <li>${data.pagination.href.next ? `<a href="${data.pagination.href.next}">Next</a>` : `Next`}</li>
       <li>${data.page.url === data.pagination.href.last ? `<a href="${data.pagination.href.last}">Last</a>` : `Last`}</li>
     </ol>


### PR DESCRIPTION
The complete code pagination example for 11ty.js filed had a couple of errors. This PR fixes them, allowing people to copy and paste to their heart's desire.

Docs page: https://www.11ty.dev/docs/pagination/nav/