### PR TITLE
chore: update description of 11st-starter-kit

### DIFF
--- a/src/_data/starters/11st-starter-kit.json
+++ b/src/_data/starters/11st-starter-kit.json
@@ -1,7 +1,7 @@
 {
 	"url": "https://github.com/stefanfrede/11st-starter-kit",
 	"name": "11st-Starter-Kit",
-	"description": "11ty, powered by Snowpack with Tailwind CSS and Alpine.js.",
+	"description": "11ty, powered by Vite with Tailwind CSS and Alpine.js.",
 	"author": "stefanfrede",
 	"demo": "https://11st-starter-kit.netlify.app/"
 }


### PR DESCRIPTION
Snowpack got replaced by Vite.