### PR TITLE
Remove hamstersquare.de from sites

### DIFF
--- a/src/_data/sites/hamstersquare.json
+++ b/src/_data/sites/hamstersquare.json
@@ -1,8 +1,0 @@
-{
-	"url": "https://www.hamstersquare.de/",
-	"name": "HamsterSquare",
-	"description": "German website for keeping hamsters as pets.",
-	"twitter": "",
-	"authoredBy": ["dennisview"],
-	"source_url": ""
-}


### PR DESCRIPTION
Remove hamstersquare.de, as it is no longer maintained