### PR TITLE
Replace HTTPS-invalid https://ndjson.org/ with GitHub link

### DIFF
--- a/src/docs/usage.md
+++ b/src/docs/usage.md
@@ -98,7 +98,7 @@ npx @11ty/eleventy --to=ndjson
 npx @11ty/eleventy --to=fs
 ```
 
-Read more about [ndjson](http://ndjson.org/).
+Read more about [ndjson](https://github.com/ndjson/ndjson-spec).
 
 
 ### `--incremental` for partial [incremental builds](/docs/usage/incremental/)


### PR DESCRIPTION
This seems to be still open after >2yrs: https://github.com/ndjson/ndjson.github.io/issues/10
I'm getting started now with the docs and I have the feeling that broken HTTPS links in the docs might jeopardize a little the respectability of the project.
HTH