### PR TITLE
Remove old “new in” statements

### DIFF
--- a/src/docs/collections.md
+++ b/src/docs/collections.md
@@ -212,7 +212,7 @@ Note in the above example that we output the `post.data.title` value? Similarly,
 
 ```js
 { inputPath: './test1.md',
-  fileSlug: 'test1', // fileSlug was added in 0.5.3
+  fileSlug: 'test1',
   outputPath: './_site/test1/index.html',
   url: '/test1/',
   date: new Date(),
@@ -354,8 +354,8 @@ module.exports = function(eleventyConfig) {
 
 ### Return values
 
-* These `addCollection` callbacks should return an array of [template objects](#collection-item-data-structure) (in Eleventy 0.5.2 and prior).
-* {% addedin "0.5.3" %} `addCollection` callbacks can now return any arbitrary object type and it’ll be available as data in the template. Arrays, strings, objects—have fun with it.
+<!-- * These `addCollection` callbacks should return an array of [template objects](#collection-item-data-structure) (in Eleventy 0.5.2 and prior). -->
+* {% addedin "0.5.3" %} `addCollection` callbacks can return any arbitrary object type and it’ll be available as data in the template. Arrays, strings, objects—have fun with it.
 
 ### Collection API Methods
 

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -70,7 +70,7 @@ npx @11ty/eleventy --input=.
 # A single file
 npx @11ty/eleventy --input=README.md
 
-# A glob of files (New in v0.6.0)
+# A glob of files
 npx @11ty/eleventy --input=*.md
 
 # A subdirectory
@@ -450,7 +450,7 @@ module.exports = function(eleventyConfig) {
     console.log( this.inputPath );
     console.log( this.outputPath );
     // note that this.outputPath is `false` for serverless templates
-    
+
     return content; // no change done.
   });
 };

--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -324,9 +324,9 @@ In order to maximize user-friendliness to beginners, Eleventy will show each fil
 | _Valid Options_ | `true` or `false` | |
 | _Command Line Override_ | `--quiet` |
 
-{% addedin "0.10.0" %} This configuration API method (`setQuietMode`) was added in v0.10.0 but note that the `--quiet` command line override existed long before that.
+<!-- {% addedin "0.10.0" %} This configuration API method (`setQuietMode`) was added in v0.10.0 but note that the `--quiet` command line override existed long before that. -->
 
-{% addedin "0.10.0" %} Added `--quiet=false` to override `setQuietMode(true)` on the command line (for deploys in production). `--quiet=true` was also added (same as `--quiet`).
+<!-- {% addedin "0.10.0" %} Added `--quiet=false` to override `setQuietMode(true)` on the command line (for deploys in production). `--quiet=true` was also added (same as `--quiet`). -->
 
 #### Example
 
@@ -440,7 +440,6 @@ module.exports = function(eleventyConfig) {
     return content; // no change done.
   });
 
-  // Support for async transforms was added in 0.7.0
   eleventyConfig.addTransform("async-transform-name", async function(content, outputPath) {
     return content; // no change done.
   });

--- a/src/docs/copy.md
+++ b/src/docs/copy.md
@@ -30,7 +30,7 @@ module.exports = function(eleventyConfig) {
   // Keeps the same directory structure.
   eleventyConfig.addPassthroughCopy("css/fonts");
 
-  // Copy any .jpg file to `_site`, via Glob pattern (in 0.9.0+)
+  // Copy any .jpg file to `_site`, via Glob pattern
   // Keeps the same directory structure.
   eleventyConfig.addPassthroughCopy("**/*.jpg");
 };

--- a/src/docs/data-eleventy-supplied.md
+++ b/src/docs/data-eleventy-supplied.md
@@ -25,10 +25,10 @@ let page = {
   // Note: This value will be `false` if `permalink` is set to `false`.
   url: "/current/page/myFile/",
 
-  // For permalinks: inputPath filename minus template file extension (New in v0.3.4)
+  // For permalinks: inputPath filename minus template file extension
   fileSlug: "myFile",
 
-  // For permalinks: inputPath minus template file extension (New in v0.9.0)
+  // For permalinks: inputPath minus template file extension
   filePathStem: "/current/page/myFile",
 
   // JS Date Object for current page (used to sort collections)

--- a/src/docs/filters.md
+++ b/src/docs/filters.md
@@ -70,7 +70,7 @@ module.exports = function(eleventyConfig) {
   // Handlebars Filter
   eleventyConfig.addHandlebarsHelper("makeUppercase", function(value) { … });
 
-  // JavaScript Template Function (New in 0.7.0)
+  // JavaScript Template Function
   eleventyConfig.addJavaScriptFunction("makeUppercase", function(value) { … });
 
   // or, use a Universal filter (an alias for all of the above)
@@ -84,7 +84,7 @@ Read more about filters on the individual Template Language documentation pages:
 
 ## Universal Filters
 
-Universal filters can be added in a single place and are available to multiple template engines, simultaneously. This is currently supported in JavaScript (New in 0.7.0), Nunjucks, Liquid, and Handlebars.
+Universal filters can be added in a single place and are available to multiple template engines, simultaneously. This is currently supported in JavaScript, Nunjucks, Liquid, and Handlebars.
 
 {% codetitle ".eleventy.js" %}
 
@@ -94,7 +94,7 @@ module.exports = function(eleventyConfig) {
   // * Liquid
   // * Nunjucks
   // * Handlebars
-  // * JavaScript (New in 0.7.0)
+  // * JavaScript
 
   eleventyConfig.addFilter("myFilter", function(value) {
     return value;

--- a/src/docs/languages/handlebars.md
+++ b/src/docs/languages/handlebars.md
@@ -53,7 +53,7 @@ Read more about [Handlebars Helpers syntax](https://handlebarsjs.com/#helpers)
 module.exports = function(eleventyConfig) {
   // Handlebars Helper
   eleventyConfig.addHandlebarsHelper("myHandlebarsHelper", function(value) { … });
-  
+
   // Universal filters (Adds to Liquid, Nunjucks, and Handlebars)
   // Read the note about Universal Filters below: Use a shortcode instead!
   eleventyConfig.addFilter("myFilter", function(value) { … });
@@ -77,10 +77,10 @@ These are not supported by Handlebars. Read more at [this Handlebars issue](http
 
 ### A note about Universal Filters
 
-Universal filters have always been funneled into Handlebars helpers. In v0.5.0, Shortcode support was added to Eleventy. Shortcodes (Paired/Single) match better with the semantic footprint of Handlebars Helpers.
+Universal filters have always been funneled into Handlebars helpers. However, shortcodes (Paired/Single) match better with the semantic footprint of Handlebars Helpers.
 
 ```js
-module.exports = function(eleventyConfig) {  
+module.exports = function(eleventyConfig) {
   // Universal filters (Adds to Liquid, Nunjucks, and Handlebars)
   eleventyConfig.addFilter("myFilter", function(value) { … });
 };
@@ -98,7 +98,7 @@ Shortcodes are basically reusable bits of content. You can add Handlebars specif
 module.exports = function(eleventyConfig) {
   // Handlebars Shortcode
   eleventyConfig.addHandlebarsShortcode("user", function(name, twitterUsername) { … });
-  
+
   // Universal Shortcodes (Adds to Liquid, Nunjucks, Handlebars)
   eleventyConfig.addShortcode("user", function(name, twitterUsername) {
     return `<div class="user">
@@ -134,7 +134,7 @@ module.exports = function(eleventyConfig) {
 module.exports = function(eleventyConfig) {
   // Handlebars Shortcode
   eleventyConfig.addPairedHandlebarsShortcode("user", function(bioContent, name, twitterUsername) { … });
-  
+
   // Universal Shortcodes (Adds to Liquid, Nunjucks, Handlebars)
   eleventyConfig.addPairedShortcode("user", function(bioContent, name, twitterUsername) {
     return `<div class="user">

--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -48,7 +48,7 @@ We enable pagination and then give it a dataset with the `data` key. We control 
   items: [], // Array of current page’s chunk of data
   pageNumber: 0, // current page number, 0 indexed
 
-  // Cool URLs, new in v0.10.0
+  // Cool URLs
   hrefs: [], // Array of all page hrefs (in order)
   href: {
     next: "…", // put inside <a href="{{ pagination.href.next }}">Next Page</a>
@@ -57,13 +57,12 @@ We enable pagination and then give it a dataset with the `data` key. We control 
     last: "…",
   },
 
-  // New in v0.10.0
   pages: [], // Array of all chunks of paginated data (in order)
   page: {
-    next: "…", // Next page’s chunk of data
-    previous: "…", // Previous page’s chunk of data
-    first: "…",
-    last: "…",
+    next: {}, // Next page’s chunk of data
+    previous: {}, // Previous page’s chunk of data
+    first: {},
+    last: {}},
   }
 }
 ```
@@ -80,7 +79,7 @@ In addition to the `pagination` object entries documented above, it also has:
   data: …, // the original string key to the dataset
   size: 1, // page chunk sizes
 
-  // Cool URLs, new in v0.6.0
+  // Cool URLs
   // Use pagination.href.next, pagination.href.previous, et al instead.
   nextPageHref: "…", // put inside <a href="{{ pagination.nextPageHref }}">Next Page</a>
   previousPageHref: "…", // put inside <a href="{{ pagination.previousPageHref }}">Previous Page</a>
@@ -94,8 +93,8 @@ In addition to the `pagination` object entries documented above, it also has:
   // Deprecated things:
   // nextPageLink
   // previousPageLink
-  // firstPageLink (new in v0.6.0)
-  // lastPageLink (new in v0.6.0)
+  // firstPageLink
+  // lastPageLink
   // pageLinks (alias to `links`)
 }
 ```

--- a/src/docs/pagination/nav.md
+++ b/src/docs/pagination/nav.md
@@ -82,8 +82,6 @@ Alright, you definitely read all of those right? 😇 Here’s some accessible c
   </div>
 </seven-minute-tabs>
 
-* `pagination.pages` was added in `0.10.0`. For previous versions, iterate over `pagination.hrefs` (although you won’t have access to the paginated items to show data about the pages).
-
 For our example, this code will output the following markup for our example (on the first page):
 
 {% codetitle "HTML", "Syntax" %}
@@ -228,8 +226,6 @@ For clarity here, we’re omitting the previous and next links from the previous
     {%- endhighlight %}
   </div>
 </seven-minute-tabs>
-
-* `pagination.href.first` and `pagination.href.last` are added in `0.10.0`. Use `pagination.firstPageHref` or `pagination.lastPageHref` in previous versions.
 
 ## Put It All Together
 

--- a/src/docs/plugins.md
+++ b/src/docs/plugins.md
@@ -67,7 +67,7 @@ module.exports = function(eleventyConfig) {
 
 ### Namespace the plugin additions
 
-You can namespace parts of your configuration using `eleventyConfig.namespace`. This will add a string prefix to all filters, tags, helpers, shortcodes (as of 0.7.0), collections, and transforms.
+You can namespace parts of your configuration using `eleventyConfig.namespace`. This will add a string prefix to all filters, tags, helpers, shortcodes, collections, and transforms.
 
 {% codetitle ".eleventy.js" %}
 

--- a/src/docs/quicktips/tag-pages.md
+++ b/src/docs/quicktips/tag-pages.md
@@ -5,9 +5,6 @@ date: 2018-06-08
 tags: ["related-pagination"]
 relatedTitle: "Quick Tip #004—Zero Maintenance Tag Pages for your Blog"
 ---
-
-_This post uses features available in Eleventy 0.4.0 and newer._
-
 This quick tip will show you how to automatically generate Tag Pages (lists of content tagged into a collection).
 
 We’ll use pagination to automatically generate a template for each tag we want to link to.

--- a/src/docs/shortcodes.md
+++ b/src/docs/shortcodes.md
@@ -78,14 +78,14 @@ module.exports = function(eleventyConfig) {
   // Handlebars Shortcode
   eleventyConfig.addHandlebarsShortcode("user", function(firstName, lastName) { … });
 
-  // JavaScript Template Function (New in 0.7.0)
+  // JavaScript Template Function
   eleventyConfig.addJavaScriptFunction("user", function(firstName, lastName) { … });
 
   // Universal Shortcodes are added to:
   // * Liquid
   // * Nunjucks
   // * Handlebars
-  // * JavaScript (New in 0.7.0)
+  // * JavaScript
   eleventyConfig.addShortcode("user", function(firstName, lastName) { … });
 };
 ```
@@ -159,14 +159,14 @@ module.exports = function(eleventyConfig) {
   // Handlebars Shortcode
   eleventyConfig.addPairedHandlebarsShortcode("user", function(content, firstName, lastName) { … });
 
-  // JavaScript Template Function (New in 0.7.0)
+  // JavaScript Template Function
   eleventyConfig.addJavaScriptFunction("user", function(content, firstName, lastName) { … });
 
   // Universal Shortcodes are added to:
   // * Liquid
   // * Nunjucks
   // * Handlebars
-  // * JavaScript (New in 0.7.0)
+  // * JavaScript
   eleventyConfig.addPairedShortcode("user", function(content, firstName, lastName) { … });
 };
 ```
@@ -180,7 +180,7 @@ Read more about using paired shortcodes on the individual Template Language docu
 
 ## Universal Shortcodes
 
-Universal shortcodes are added in a single place and subsequently available to multiple template engines, simultaneously. This is currently supported in JavaScript (New in 0.7.0), Nunjucks, Liquid, and Handlebars template types.
+Universal shortcodes are added in a single place and subsequently available to multiple template engines, simultaneously. This is currently supported in JavaScript, Nunjucks, Liquid, and Handlebars template types.
 
 {% codetitle ".eleventy.js" %}
 
@@ -190,7 +190,7 @@ module.exports = function(eleventyConfig) {
   // * Liquid
   // * Nunjucks
   // * Handlebars
-  // * JavaScript (New in 0.7.0)
+  // * JavaScript
 
   // Single Universal Shortcode
   eleventyConfig.addShortcode("myShortcode", function(firstName, lastName) { … });


### PR DESCRIPTION
While old `{% addedin %}` statements were removed in f2b5c698fffd728b2c4200fdb2bc71ce5491cd75, manual references to old versions (including in code blocks) were not cleaned up. This PR does that, and fixes a place where the missing old `{% addedin %}` was actively confusing (https://www.11ty.dev/docs/collections/#return-values)