### PR TITLE
Fix statox.fr author

### DIFF
--- a/src/_data/sites/statox.json
+++ b/src/_data/sites/statox.json
@@ -2,5 +2,6 @@
     "url": "https://www.statox.fr/",
     "name": "The stuff I do",
     "description": "The personal blog of a backend software engineer",
-    "source_url": "https://github.com/statox/blog/"
+    "source_url": "https://github.com/statox/blog/",
+    "authoredBy" : ["statox"]
 }


### PR DESCRIPTION
I didn't realize that either `twitter` or `authoredBy` properties are needed for the site to show up in the page.

Sorry for the additional noise :see_no_evil: 