### PR TITLE
Update node-fetch install in eliminate-js.md

### DIFF
--- a/src/docs/quicktips/eliminate-js.md
+++ b/src/docs/quicktips/eliminate-js.md
@@ -16,7 +16,7 @@ Read more at the [GitHub API documentation](https://developer.github.com/v3/repo
 
 This is a bit different from our client-side implementation because this data is only updated as often as your build runs. This is implemented using a global [JavaScript data file](/docs/data-js/) at `_data/github.js`.
 
-* Install new dependencies: `npm install node-fetch@2.0 --save-dev`
+* Install new dependencies: `npm install node-fetch@cjs --save-dev`
 * Read more about [`node-fetch`](https://www.npmjs.com/package/node-fetch)
 
 {% codetitle "_data/github.js" %}

--- a/src/docs/quicktips/eliminate-js.md
+++ b/src/docs/quicktips/eliminate-js.md
@@ -16,7 +16,7 @@ Read more at the [GitHub API documentation](https://developer.github.com/v3/repo
 
 This is a bit different from our client-side implementation because this data is only updated as often as your build runs. This is implemented using a global [JavaScript data file](/docs/data-js/) at `_data/github.js`.
 
-* Install new dependencies: `npm install node-fetch --save-dev`
+* Install new dependencies: `npm install node-fetch@2.0 --save-dev`
 * Read more about [`node-fetch`](https://www.npmjs.com/package/node-fetch)
 
 {% codetitle "_data/github.js" %}


### PR DESCRIPTION
> node-fetch was converted to be a ESM only package in version 3.0.0-beta.10. node-fetch is an ESM-only module - you are not able to import it with require. We recommend you stay on v2 which is built with CommonJS unless you use ESM yourself. We will continue to publish critical bug fixes for it.

[source](https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md#converted-to-es-module)