### PR TITLE
example: this.outputPath --> outputPath

### DIFF
--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -460,7 +460,7 @@ const htmlmin = require("html-minifier");
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addTransform("htmlmin", function(content, outputPath) {
-    // Eleventy 1.0+: use this.inputPath and this.outputPath instead
+    // Eleventy 1.0+: use this.inputPath and outputPath instead
     if( outputPath && outputPath.endsWith(".html") ) {
       let minified = htmlmin.minify(content, {
         useShortDoctype: true,


### PR DESCRIPTION
I was adding `html-minifier` transform to my starter, and I noticed that the docs say to use `this.inputPath` and `this.outputPath`. However, `this.outputPath` is `undefined`, so I assume `this` should only be used for the `inputPath`?