### PR TITLE
Fix file extension typo on custom template documentation page

### DIFF
--- a/src/docs/languages/custom.md
+++ b/src/docs/languages/custom.md
@@ -48,7 +48,7 @@ Situations where you might want to use `addExtension` but probably shouldn’t:
 
 ## Example: Add Sass support to Eleventy
 
-For a more realistic sample, here’s an example of Eleventy looking for all `.sass` files in a project’s input directory to process them to your output directory.
+For a more realistic sample, here’s an example of Eleventy looking for all `.scss` files in a project’s input directory to process them to your output directory.
 
 {% codetitle ".eleventy.js" %}
 


### PR DESCRIPTION
The documentation pages talk about using `.sass` files but then use `.scss` in the example. I updated the paragraph prior to the example to use the same extension for consistency.