### PR TITLE
Add eleventy-plugin-broken-links to community plugins list

### DIFF
--- a/src/_data/plugins/eleventy-plugin-broken-links.json
+++ b/src/_data/plugins/eleventy-plugin-broken-links.json
@@ -1,5 +1,5 @@
 {
   "npm": "eleventy-plugin-broken-links",
-  "author": "bradleyburgess",
+  "author": "bburgess_keys",
   "descrption": "A plugin to check your build for broken external links and redirects"
 }

--- a/src/_data/plugins/eleventy-plugin-broken-links.json
+++ b/src/_data/plugins/eleventy-plugin-broken-links.json
@@ -1,0 +1,5 @@
+{
+  "npm": "eleventy-plugin-broken-links",
+  "author": "bradleyburgess",
+  "descrption": "A plugin to check your build for broken external links and redirects"
+}


### PR DESCRIPTION
This plugin checks your build for broken and redirected external links. It allows for warning in the build log output (including showing which input files contain the offending links), or throwing an error if external links are broken.

[GitHub repo](https://github.com/bradleyburgess/eleventy-plugin-broken-links)