### PR TITLE
Community plugin: Fixed typo; corrected handle (github not twitter)

### DIFF
--- a/src/_data/plugins/eleventy-plugin-broken-links.json
+++ b/src/_data/plugins/eleventy-plugin-broken-links.json
@@ -1,5 +1,5 @@
 {
   "npm": "eleventy-plugin-broken-links",
-  "author": "bburgess_keys",
-  "descrption": "A plugin to check your build for broken external links and redirects"
+  "author": "bradleyburgess",
+  "description": "A plugin to check your build for broken external links and redirects"
 }


### PR DESCRIPTION
Fixed a typo and changed to github handle for my community plugin, `eleventy-plugin-broken-links`.