### PR TITLE
Fix contrast ratio issue for TOC links

### DIFF
--- a/src/_includes/components/toc.css
+++ b/src/_includes/components/toc.css
@@ -58,7 +58,7 @@
 .elv-toc summary,
 .elv-toc-list a {
 	padding: .15em .25em;
-	color: #1873a9;
+	color: #1873a5;
 }
 @media (prefers-color-scheme: dark) {
 	.elv-toc summary,


### PR DESCRIPTION
When a section headline uses inline code (`example`), its entry in the table of contents uses a style that is not sufficient from WCAG AA perspective. I have fixed this by changing the color slightly from `#1873a9` to `#1873a5`.

- Example page: [11ty Docs Home page](https://www.11ty.dev/docs/)

## Before

- Contrast ratio: `4.49`

![image](https://user-images.githubusercontent.com/3101914/167251468-f3dc8388-9174-462d-bf6e-b06dd708fddd.png)


## After

- Contrast ratio: `4.53`

![image](https://user-images.githubusercontent.com/3101914/167251458-95838afc-a3a0-49ab-9c69-189b5d0cc754.png)
