### PR TITLE
Create 11ty-blog-njk-starter

### DIFF
--- a/src/_data/starters/11ty-blog-njk-starter
+++ b/src/_data/starters/11ty-blog-njk-starter
@@ -1,0 +1,6 @@
+{
+  "url": "https://github.com/httpsterio/11ty-blog-njk-starter",
+  "name": "11ty-blog-njk-starter",
+  "description": "Forked from Rong Ying's starter, now with njk and a few tiny fixes",
+  "demo": "https://11ty-blog-njk-starter.netlify.app"
+}


### PR DESCRIPTION
Added a forked version of Rong Ying's starter. I've converted it to use njk instead of liquid and fixed some tiny accessibility and performance issues as well.