### PR TITLE
Fix github icon styles and add gitlab icon

### DIFF
--- a/src/_includes/components/external-links.css
+++ b/src/_includes/components/external-links.css
@@ -59,7 +59,12 @@ a[href^="https://twitter.com"]:before {
 }
 a[href^="https://github.com"]:before {
 	border-radius: 0.3125em; /* 5px /16 */
+	border: .5px solid #fff;
+	background-color: #fff;
 	background-image: url("https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Fgithub.com%2F/");
+}
+a[href^="https://gitlab.com"]:before {
+	background-image: url("https://v1.indieweb-avatar.11ty.dev/https%3A%2F%2Fabout.gitlab.com%2F/");
 }
 a[href^="https://wikipedia.org"]:before,
 a[href^="https://en.wikipedia.org"]:before {


### PR DESCRIPTION
Before:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/1126370/172294250-50e48a3d-a0f6-42b4-aaf0-ba87601bb08c.png">

After:

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/1126370/172294154-99d5ea64-392f-4270-bf15-58833f740d8d.png">


I wasn't able to run locally due to the following errors with both node 14 and node 16, which means I couldn't verify the gitlab icon... but the url for it looks snazzy 😬 

```sh
❯ npx @11ty/eleventy --serve
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] Cannot read property '0' of undefined (via TypeError)
[11ty] 
[11ty] Original error stack trace: TypeError: Cannot read property '0' of undefined
[11ty]     at /Users/charlie/Developer/11ty/11ty-website/node_modules/@11ty/eleventy/src/Plugins/Pagination.js:316:61
[11ty]     at Array.map (<anonymous>)
[11ty]     at Pagination.getPageTemplates (/Users/charlie/Developer/11ty/11ty-website/node_modules/@11ty/eleventy/src/Plugins/Pagination.js:316:41)
[11ty]     at Template.getTemplates (/Users/charlie/Developer/11ty/11ty-website/node_modules/@11ty/eleventy/src/Template.js:668:45)
```