### PR TITLE
Remove plugin from list in favour of solution provided by core

### DIFF
--- a/src/_data/plugins/eleventy-plugin-meta-generator.json
+++ b/src/_data/plugins/eleventy-plugin-meta-generator.json
@@ -1,5 +1,0 @@
-{
-	"npm": "eleventy-plugin-meta-generator",
-	"author": "AndreJaenisch",
-	"description": "will render a generator <meta> tag for you."
-}


### PR DESCRIPTION
https://www.11ty.dev/docs/data-eleventy-supplied/#eleventy-variable provides everything that's needed (via `eleventy.generator`).
As such, I marked my plugin as deprecated and archived the repository. Last thing to do is to update the plugin list.

Related https://github.com/11ty/eleventy/issues/1217

Signed-off-by: André Jaenisch <andre.jaenisch@posteo.de>