### PR TITLE
Update community article URL and author's name

### DIFF
--- a/src/_data/community/javascript-willmartian.js
+++ b/src/_data/community/javascript-willmartian.js
@@ -1,6 +1,6 @@
 module.exports = {
-  url: "https://willmartin.dev/posts/conditional-rendering-eleventy/",
-  author: "willmartindev",
+  url: "https://willmartian.com/posts/conditional-rendering-eleventy/",
+  author: "willmartian",
   title: "Conditionally Rendering JavaScript Templates",
   key: "javascript",
 };


### PR DESCRIPTION
Since originally writing this article, I have started using an new domain and GitHub name.