### PR TITLE
11ty/eleventy#2466 Add documentation for skip in pagination

### DIFF
--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -723,6 +723,38 @@ The above will iterate over a data set containing: `["item1 with a suffix", "ite
 
 You can do anything in this `before` callback. Maybe a custom `.sort()`, `.filter()`, `.map()` to remap the entries, `.slice()` to paginate only a subset of the data, etc!
 
+### Skipping Items {% addedin "2.0.0" %}
+
+Sometimes you might want to skip some of the first items in your data (e.g. because you already show them somewhere else).
+
+{% codetitle "YAML Front Matter", "Syntax" %}
+
+```markdown
+---
+pagination:
+  data: testdata
+  size: 2
+  skip: 1
+testdata:
+  - item1
+  - item2
+  - item3
+  - item4
+  - item5
+---
+```
+
+Paginates to:
+
+{% codetitle "JavaScript Object", "Syntax" %}
+
+```js
+[
+  [ "item2", "item3" ],
+  [ "item4", "item5" ],
+]
+```
+
 ### Order of Operations
 
 If you use more than one of these data set modification features, here’s the order in which they operate:
@@ -730,6 +762,7 @@ If you use more than one of these data set modification features, here’s the o
 * The `before` callback
 * `reverse: true`
 * `filter` entries
+* `skip` entries
 
 ## Add All Pagination Pages to Collections {% addedin "0.8.0" %}
 


### PR DESCRIPTION
The referenced PR adds the skip parameter and this one adds the required documentation.

The "addedin" will probably need to be updated once the referenced PR got merged.