### PR TITLE
feat: make search page's search input autofocused

### DIFF
--- a/src/docs/search.njk
+++ b/src/docs/search.njk
@@ -10,7 +10,7 @@ css:
 	<div class="search-lo lo">
 		<div class="lo-c lo-maxgrow">
 			<label for="search-term" class="sr-only">Search Terms</label>
-			<input type="search" name="q" id="search-term" class="search-txt" autocomplete="off">
+			<input type="search" name="q" id="search-term" class="search-txt" autocomplete="off" autofocus>
 			<input aria-hidden="true" hidden name="sites" value="www.11ty.dev">
 		</div>
 		<div class="lo-c">


### PR DESCRIPTION
when using the keyboard to navigate 11ty docs, getting to the search input requires tabbing through multiple navigation links before getting to the critical feature of the search page: the search input.