### PR TITLE
Fix xml:base value, add xml:lang to Atom example

### DIFF
--- a/src/docs/plugins/rss.md
+++ b/src/docs/plugins/rss.md
@@ -116,7 +116,7 @@ Copy and paste this template and modify the JSON metadata to match your feed’s
 }
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.language }}">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ metadata.url }}">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.subtitle }}</subtitle>
   <link href="{{ permalink | url | absoluteUrl(metadata.url) }}" rel="self"/>
@@ -134,7 +134,7 @@ Copy and paste this template and modify the JSON metadata to match your feed’s
     <link href="{{ absolutePostUrl }}"/>
     <updated>{{ post.date | dateToRfc3339 }}</updated>
     <id>{{ absolutePostUrl }}</id>
-    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+    <content xml:lang="{{ metadata.language }}" type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
   </entry>
   {%- endfor %}
 </feed>


### PR DESCRIPTION
- Fixes what I think is a mistype: language — url
- Adds missing language value

I’m not sure if setting the global language for the whole feed is even possible, like in RSS. I could only find Atom examples with `xml:lang` applied to the `<content>` element of every entry.