### PR TITLE
Simplify set usage in Atom template

### DIFF
--- a/src/docs/plugins/rss.md
+++ b/src/docs/plugins/rss.md
@@ -128,7 +128,7 @@ Copy and paste this template and modify the JSON metadata to match your feed’s
     <email>{{ metadata.author.email }}</email>
   </author>
   {%- for post in collections.posts | reverse %}
-  {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
+  {%- set absolutePostUrl = post.url | url | absoluteUrl(metadata.url) %}
   <entry>
     <title>{{ post.data.title }}</title>
     <link href="{{ absolutePostUrl }}"/>


### PR DESCRIPTION
The same snippet is already used in RSS and JSON samples, so it’s just a normalization.

This one definitely looks simpler :)