### PR TITLE
Update index.css

### DIFF
--- a/src/_includes/index.css
+++ b/src/_includes/index.css
@@ -59,6 +59,11 @@ strong,
 b {
 	font-weight: 600;
 }
+s,
+del {
+    text-decoration-color: red;
+    opacity: 0.67;
+}
 hr {
 	margin: 3em 0;
 	border: none;


### PR DESCRIPTION
Add CSS for ~~deleted/strikethrough~~ text (`s, del`).

I was reading the [Order of Operations](https://www.11ty.dev/docs/advanced-order/) page, and the text with the line-through it (a bullet under Step 7) is visually noisy.

This PR adds a minimal amount of style that:

* makes the line going through the text red (use color to reinforce the line’s role in marking the text as no-longer-current)
* dims the text a bit (so it’s a little easier to skip over)

As a result, the text is easy to skip over, but still legible for anyone wondering what the (now-deleted) text used to say.
