### PR TITLE
Soft-recommend slugify in two more examples

### DIFF
--- a/src/docs/pages-from-data.md
+++ b/src/docs/pages-from-data.md
@@ -44,7 +44,7 @@ pagination:
     data: possums
     size: 1
     alias: possum
-permalink: "possums/{{ possum.name | slug }}/"
+permalink: "possums/{{ possum.name | slugify }}/"
 ---
 
 {{ possum.name }} is {{ possum.age }} years old

--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -363,7 +363,7 @@ pagination:
   size: 1
 testdata:
   - My Item
-permalink: "different/{{ pagination.items[0] | slug }}/index.html"
+permalink: "different/{{ pagination.items[0] | slugify }}/index.html"
 ---
 ```
 {% endraw %}
@@ -391,7 +391,7 @@ pagination:
 testdata:
   - Item1
   - Item2
-permalink: "different/{{ wonder | slug }}/index.html"
+permalink: "different/{{ wonder | slugify }}/index.html"
 ---
 You can use the alias in your content too {{ wonder }}.
 ```
@@ -412,7 +412,7 @@ pagination:
 testdata:
   - Item1
   - Item2
-permalink: "different/{{ wonder | slug }}/index.html"
+permalink: "different/{{ wonder | slugify }}/index.html"
 ---
 You can use the alias in your content too {{ wonder }}.
 ```
@@ -454,7 +454,7 @@ testdata:
   - Item2
   - Item3
   - Item4
-permalink: "different/{{ wonder[0] | slug }}/index.html"
+permalink: "different/{{ wonder[0] | slugify }}/index.html"
 ---
 You can use the alias in your content too {{ wonder[0] }}.
 ```
@@ -477,7 +477,7 @@ testdata:
   - Item2
   - Item3
   - Item4
-permalink: "different/{{ wonder[0] | slug }}/index.html"
+permalink: "different/{{ wonder[0] | slugify }}/index.html"
 ---
 You can use the alias in your content too {{ wonder[0] }}.
 ```


### PR DESCRIPTION
Based on the comments in https://github.com/11ty/eleventy/issues/278#issuecomment-872278835, `slugify` should be soft-recommended instead of `slug`. 

https://github.com/11ty/11ty-website/pull/1285 already updated one of the examples, this PR tweaks two other main uses of slug (in pages-from-data and pagination examples).

(Semi-related question, `pages-from-data` uses a `permalink` that ends in `/`, whereas `pagination.md` uses examples that end in `/index.html` is one of those the "correct" recommended approach? I'd like to make them consistent while I'm at it 🙂 )