### PR TITLE
Fix serverless plugin excerpt link inlining

### DIFF
--- a/src/docs/plugins/serverless.md
+++ b/src/docs/plugins/serverless.md
@@ -8,7 +8,7 @@ overrideCommunityLinks: true
 ---
 # Serverless {% addedin "1.0.0" %}
 
-{{ eleventyNavigation.excerpt }}
+{{ eleventyNavigation.excerpt | safe }}
 
 <details class="toc">
 <summary>Expand for contents</summary>


### PR DESCRIPTION
The inlined link from the excerpt is escaped by nunjucks by default. This pipes the excerpt through `safe`, so it gets inlined correctly.