### PR TITLE
logos: add red hat

### DIFF
--- a/src/_includes/logos.njk
+++ b/src/_includes/logos.njk
@@ -31,5 +31,6 @@
   #}<li>{% indieavatar "https://www.orange.com/" %}Orange</li>{#
   #}<li>{% indieavatar "https://www.wisc.edu/" %}Univ. of Wisconsin-Madison</li>{#
   #}<li>{% indieavatar "https://www.numerique.gouv.fr/" %}The government of France</li>{#
+  #}<li>{% indieavatar "https://ux.redhat.com" %}Red Hat</li>{#
   #}<li class="logos-list-more">…and more</li>{#
 #}</ul>


### PR DESCRIPTION
Red Hat uses 11ty for a variety of properties, it would be swell to add them to the users grid.