### PR TITLE
Update example and copy from slug to slugify

### DIFF
--- a/src/docs/pages-from-data.md
+++ b/src/docs/pages-from-data.md
@@ -44,14 +44,14 @@ pagination:
     data: possums
     size: 1
     alias: possum
-permalink: "possums/{{ possum.name | slug }}/"
+permalink: "possums/{{ possum.name | slugify }}/"
 ---
 
 {{ possum.name }} is {{ possum.age }} years old
 ```
 {% endraw %}
 
-This template will generate four files, one for each possum, where the filename is based on the possum's name passed through the `slug` function. As possums are added and edited the resultant possum details page will be updated automatically.
+This template will generate four files, one for each possum, where the filename is based on the possum's name passed through the [`slugify`](https://www.11ty.dev/docs/filters/slugify/) function. As possums are added and edited the resultant possum details page will be updated automatically.
 
 {% callout "info" %}Note that <code>page</code> is a reserved word so you cannot use <code>alias: page</code>. Read about Eleventy’s reserved data names in <a href="/docs/data-eleventy-supplied">Eleventy Supplied Data</a>.{% endcallout %}
 


### PR DESCRIPTION
On [Create Pages From Data](https://www.11ty.dev/docs/pages-from-data/), the template example shown uses the `slug` filter, which is no longer recommended according to [this page](https://www.11ty.dev/docs/filters/slugify/):

> In versions prior to 1.0.0, [the slug Universal Filter was used](https://www.11ty.dev/docs/filters/slug/). To maintain backwards compatibility moving forward, slug is still included and supported but slugify is now recommended as best practice—it has better default behavior for URLs with special characters.

Hope I'm not trying to PR wrong information, but it seems like this example and copy should be updated so that folks are using the correct filter. Let me know if you'd like to add anything else!