### PR TITLE
Please add the toc-extract plugin to the list

### DIFF
--- a/src/_data/plugins/toc-extract.json
+++ b/src/_data/plugins/toc-extract.json
@@ -1,0 +1,5 @@
+{
+  "npm": "toc-extract",
+  "description": "extracts a table of contents from HTML, with emphasis on separation of concerns and flexibility."
+}
+


### PR DESCRIPTION
Hi everyone,

this PR adds the toc-extract plugin to the list of plugins in the docs.

While there already exist two other plugins that do the same thing, in my particular case I encountered problems that ultimately kept me from using them. I didn't feel comfortable contributing to the existing plugins since both have no LICENSE file, so I decided to write a new plugin from scratch.

The toc-extract plugin puts special emphasis on separation of concerns and good configurability (e.g. working config overrides from Liquid, custom filter name). It comes with a test suite that covers the underlying functions and a bundled example project for the Eleventy plugin. (And it has a LICENSE file :wink:)

Please consider adding toc-extract to the list of plugins.

Thank you and Best Regards
Lucas Hinderberger