### PR TITLE
Fixes username in `eleventy-plugin-target-safe.json`

### DIFF
--- a/src/_data/plugins/eleventy-plugin-target-safe.json
+++ b/src/_data/plugins/eleventy-plugin-target-safe.json
@@ -1,5 +1,5 @@
 {
   "npm": "eleventy-plugin-target-safe",
-  "author": "gingercheww",
+  "author": "gingerchew",
   "description": "Link tags with the target attribute may need a rel attribute. This plugin does that for you automatically."
 }


### PR DESCRIPTION
Noticed the profile picture on the plugin list wasn't loading. The example [here](https://github.com/11ty/11ty-website/tree/main/src/_data/plugins#eleventy-community-plugins) says to use your Twitter profile, but the profile picture on the plugin list checks GitHub user content.

My usernames are *unfortunately* 1 character off, `gingerchew` vs `gingercheww`, I can also update the example readme in this PR since I'm already here :)