### PR TITLE
Docs: Adds Liquid pagination starter example

### DIFF
--- a/src/_includes/examples/pagination/nav/starter.liquid
+++ b/src/_includes/examples/pagination/nav/starter.liquid
@@ -1,0 +1,10 @@
+{% raw %}
+<nav aria-labelledby="my-pagination">
+  <h2 id="my-pagination">This is my Pagination</h2>
+  <ol>
+{%- for pageEntry in pagination.pages %}
+    <li><a href="{{ pagination.hrefs[ forloop.index0 ] }}"{% if page.url == pagination.hrefs[ forloop.index0 ] %} aria-current="page"{% endif %}>Page {{ forloop.index }}</a></li>
+{%- endfor %}
+  </ol>
+</nav>
+{% endraw %}

--- a/src/docs/pagination/nav.md
+++ b/src/docs/pagination/nav.md
@@ -101,9 +101,12 @@ Alright, you definitely read all of those right? 😇 Here’s some accessible c
 
 <is-land on:visible import="/js/seven-minute-tabs.js">
 <seven-minute-tabs>
-  {% renderFile "./src/_includes/syntax-chooser-tablist.11ty.js", {id: "paged-nav-starter", valid: "njk,js" } %}
+  {% renderFile "./src/_includes/syntax-chooser-tablist.11ty.js", {id: "paged-nav-starter", valid: "liquid,njk,js" } %}
   <div id="paged-nav-starter-liquid" role="tabpanel">
-    <p><em>This example has not yet been added—you can swap to another template language above! Or maybe you want to contribute it? {% include "edit-on-github.njk" %}</em></p>
+    {%- codetitle "starter.liquid" %}
+    {%- highlight "html" %}
+    {%- include "examples/pagination/nav/starter.liquid" %}
+    {%- endhighlight %}  
   </div>
   <div id="paged-nav-starter-njk" role="tabpanel">
     {%- codetitle "starter.njk" %}


### PR DESCRIPTION
This PR adds a Liquid template example to those already listed in:

https://www.11ty.dev/docs/pagination/nav/#starter-example

The example is a duplicate of the Nunjucks example code, but with Nunjucks' `loop` property replaced with Liquid's `forloop` equivalent.

