### PR TITLE
 Update author info

### DIFF
--- a/src/_data/starters/eleventy-excellent.json
+++ b/src/_data/starters/eleventy-excellent.json
@@ -1,7 +1,7 @@
 {
 	"url": "https://github.com/madrilene/eleventy-excellent",
-	"name": " eleventy-excellent",
-	"description": "Very opiniated Eleventy starter. Based on the companion website of Andy Bell’s talk ‘Be the browser’s mentor, not its micromanager’.",
-	"author": "madrilene",
+	"name": "eleventy-excellent",
+	"description": "Opiniated but easy to use. Based on the companion website of Andy Bell’s talk ‘Be the browser’s mentor, not its micromanager’.",
+	"author": "lene",
 	"demo": "https://eleventy-excellent.netlify.app/"
 }


### PR DESCRIPTION
There is a discrepancy between the author archive "Lene", with reference to me supporting Open Collective, and the detail, "madrilene" (set as not supporting). Not sure where to change it, so I'll try here! Would like it to be generally "Lene" or "Lene Saile"