### PR TITLE
Fix wrong file extension

### DIFF
--- a/src/docs/layouts.md
+++ b/src/docs/layouts.md
@@ -33,7 +33,7 @@ title: My Rad Markdown Blog Post
 {% raw %}
 ```liquid
 ---
-layout: mylayout.njk
+layout: mylayout.liquid
 title: My Rad Liquid Blog Post
 ---
 <h1>{{ title }}</h1>


### PR DESCRIPTION
I think `.liquid` is a proper file extension for Liquid template