### PR TITLE
Fix link to base blog tags template

### DIFF
--- a/src/docs/quicktips/tag-pages.md
+++ b/src/docs/quicktips/tag-pages.md
@@ -77,4 +77,4 @@ Now Eleventy will only generate a `/tags/personal/` template and `tech` will be 
 
 ## In Practice
 
-This is currently in use on the [`eleventy-base-blog` sample project](https://github.com/11ty/eleventy-base-blog). Check out source code in the [`tags.njk` template](https://github.com/11ty/eleventy-base-blog/blob/master/tags.njk) and [see a live demo](https://eleventy-base-blog.netlify.com/tags/another-tag/).
+This is currently in use on the [`eleventy-base-blog` sample project](https://github.com/11ty/eleventy-base-blog). Check out source code in the [`tags.njk` template](https://github.com/11ty/eleventy-base-blog/blob/main/content/tags.njk) and [see a live demo](https://eleventy-base-blog.netlify.com/tags/another-tag/).


### PR DESCRIPTION
The previous link 404s after this commit https://github.com/11ty/eleventy-base-blog/commit/216a9de439076b96b2b4e98f8414ba617b279487. This PR updates the link to the correct page.