### PR TITLE
Add note about overriding tags on Collections page

### DIFF
--- a/src/docs/collections.md
+++ b/src/docs/collections.md
@@ -329,7 +329,19 @@ tags:
 
 This content would show up in the template data inside of `collections.cat` and `collections.dog`.
 
-### Collection Item Data Structure
+### Override tags
+
+As of Eleventy 1.0, the Data Cascade is combined using [deep data merge](/docs/data-deep-merge/) by default, which means any tags added in the front matter get added to tags defined higher up in the cascade. To redefine `tags` in the front matter use [the `override:` prefix](/docs/data-deep-merge/#using-the-override-prefix):
+
+```markdown
+---
+override:tags: []
+---
+``` 
+
+This content would not show up in any of the collections it was added to with `tags` higher up in the data cascade.
+
+## Collection Item Data Structure
 
 
 <is-land on:visible import="/js/seven-minute-tabs.js">


### PR DESCRIPTION
Added a brief note about overriding tags directly on the Collections page, since at first I just assumed merging tag arrays was the only option available to authors and was unaware of the `override:` prefix. 

Also included a drive-by fix to the heading level for the _Collection Item data structure_ section.

(I couldn't get the local website to start, but hopefully everything looks okay)