### PR TITLE
Fix docs button for the more better accessibility

### DIFF
--- a/src/_includes/index.css
+++ b/src/_includes/index.css
@@ -822,7 +822,7 @@ main .elv-toc + h1 .direct-link {
 	}
 }
 @media (min-height:50em){
-	.why-are-you-doing-this {
+	html:not(:has(:focus-visible)) .why-are-you-doing-this {
 		position: sticky;
 		top: 10px;
 		z-index: 10;


### PR DESCRIPTION
As pointed out here:
https://hachyderm.io/@hi_mayank/109842565225113127

> i think the sticky positioning could cause an accessibility issue where it could hide currently focused items
> 
> there's success criteria for it in WCAG 2.2 (https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html)
> 
> (sorry to be a party pooper 😅)

This PR solves this issue by adding an additional selector of `html:not(:has(:focus-visible))` which will remove the sticky positioning if the focus is visible on the page.

I think this will solve the a11y issue.