### PR TITLE
Add info on webc syntax highlighting

### DIFF
--- a/src/docs/languages/webc.md
+++ b/src/docs/languages/webc.md
@@ -110,6 +110,12 @@ module.exports = function(eleventyConfig) {
 
 </details>
 
+### Syntax highlighting
+
+Because WebC _is_ HTML you can configure your editor to treat `.webc` files as
+HTML, this should correctly syntax highlight your WebC files. Your editor of
+choice should have some documentation on how to get this working.
+
 
 ## Usage
 


### PR DESCRIPTION
See https://github.com/11ty/webc/issues/130

Let me know if there's a better place or other places it needs to be added to too.