### PR TITLE
Add note on where the env variables are available

### DIFF
--- a/src/docs/environment-vars.md
+++ b/src/docs/environment-vars.md
@@ -12,6 +12,8 @@ You can set and use your own environment variables in your projects. They will b
 
 These are typically used for setting your deployment context and private API keys. This is also the approach used to [enable `DEBUG` mode](/docs/debugging/).
 
+{% callout "info", "md" %}Note that Eleventy exposes environment variables only to JavaScript files that are evaluated during the build time. This includes the config file and all JavaScript files required from there, JavaScript data files, etc. **Environment variables are not available in the templates.** You need to expose them yourself. For example, using a [Global Data file](/docs/data-js/#example-exposing-environment-variables).{% endcallout %}
+
 [[toc]]
 
 ## Setting your own


### PR DESCRIPTION
As of now, the wording is quite broad and may create confusion.

https://www.11ty.dev/docs/environment-vars/
> You can set and use your own environment variables in your projects. They will be available in your code…

One may think that the environment variables are available in all the code, from templates to JS assets. It may take time to understand the truth.

This PR adds a note in the beginning that explains the borders of applicability.

I'm not sure about the JS templates, whether env vars are exposed there or not. The whole note text needs scrupulous check by a maintainer since it's just my understanding of how it works.
