### PR TITLE
Update WebC JS bundle examples

### DIFF
--- a/src/docs/languages/webc.md
+++ b/src/docs/languages/webc.md
@@ -1212,11 +1212,13 @@ You can opt-out of bundling on a per-element basis [using `webc:keep`](#webckeep
 
 		<!-- inline bundles -->
 		<style @raw="getBundle('css')" webc:keep></style>
-		<script @raw="getBundle('js')" webc:keep></script>
+		<!-- `type="module" is required for Web Components to work -->
+		<script type="module" @raw="getBundle('js')" webc:keep></script>
 
 		<!-- or write your bundle to a file -->
 		<link rel="stylesheet" :href="getBundleFileUrl('css')">
-		<script :src="getBundleFileUrl('js')"></script>
+		<!-- `type="module" is required for Web Components to work -->
+		<script type="module" :src="getBundleFileUrl('js')"></script>
 	</head>
 	<body @raw="content"></body>
 </html>
@@ -1402,4 +1404,3 @@ At the component level, components can declare their own is-land loading conditi
 	</template>
 </is-land>
 ```
-


### PR DESCRIPTION
Without `type="module" on the `<script>` tag for JS bundles, Web Components won't work.

This isn't documented and can be difficult to figure out independently. The only way I found this out was spotting it briefly at 1:02 of the [Interactive Progressively-enhanced Web Components with WebC video](https://www.youtube.com/watch?v=p0wDUK0Z5Nw) and finding it in the base layout for the 11ty website itself.

If it's safe to use as a default, this would prevent issues if a WebC component happens to be an actual Web Component. It may even be good to explicitly call out, perhaps in a section dedicated to creating actual Web Components?