### PR TITLE
chore(terminal window): adds web storm as editor bundled w/terminal

### DIFF
--- a/src/docs/terminal-window.md
+++ b/src/docs/terminal-window.md
@@ -32,3 +32,4 @@ Depending on your version of Windows, it may include the `Terminal` App (aka Win
 * [Nova](https://nova.app/) (Mac OS)
 * [Visual Studio Code](https://code.visualstudio.com/) (Mac OS, Windows, Linux)
   * On Windows, Visual Studio Code is bundled with Windows Powershell.
+* [WebStorm](https://www.jetbrains.com/webstorm/) (Mac OS, Windows, Linux)


### PR DESCRIPTION
- Adds WebStorm by JetBrains as an option for editors with bundled terminals