### PR TITLE
Add 11ty-sensible starter

### DIFF
--- a/src/_data/starters/11ty-sensible.json
+++ b/src/_data/starters/11ty-sensible.json
@@ -1,6 +1,5 @@
 {
 	"url": "https://gitlab.com/alexmozaidze/11ty-template-sensible",
 	"name": "11ty-sensible",
-	"description": "11ty with sensible defaults. SCSS, excerpts, minification and more!",
-	"demo": ""
+	"description": "11ty with sensible defaults. SCSS, excerpts, minification and more!"
 }

--- a/src/_data/starters/11ty-sensible.json
+++ b/src/_data/starters/11ty-sensible.json
@@ -1,0 +1,6 @@
+{
+	"url": "https://gitlab.com/alexmozaidze/11ty-template-sensible",
+	"name": "11ty-sensible",
+	"description": "11ty with sensible defaults. SCSS, excerpts, minification and more!",
+	"demo": ""
+}


### PR DESCRIPTION
I made a minimalist 11ty starter project with no demo that focuses on delivering sensible defaults for people to build upon. For full set of features refer to the project's [README](https://gitlab.com/alexmozaidze/11ty-template-sensible).