### PR TITLE
Add elva starter project

### DIFF
--- a/src/_data/starters/elva.json
+++ b/src/_data/starters/elva.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/scottsweb/elva",
+	"name": "elva",
+	"description": "A multilingual, clean, green, 11ty starter theme. elva provides solid foundations for your next web project and a built in CMS (Front Matter CMS) for managing content.",
+	"author": "scottsweb",
+	"demo": "https://elva.scott.ee"
+}


### PR DESCRIPTION
Adding elva as a starter project:

> A multilingual, clean, green, 11ty starter theme. elva provides solid foundations for your next web project and a built in CMS (Front Matter CMS) for managing content.

https://github.com/scottsweb/elva