### PR TITLE
Update rss.md - add specifics for feed template name and location

### DIFF
--- a/src/docs/plugins/rss.md
+++ b/src/docs/plugins/rss.md
@@ -240,7 +240,7 @@ Copy and paste this template and modify the JSON metadata to match your feed’s
 </div>
 </seven-minute-tabs>
 
-Place the file anywhere in your project (give it a `.njk` extension) and it will be transformed into a `feed.xml` (or `feed.json` if you’re using the JSON variant) file at the root of your website when Eleventy builds it. It can then be useful to check the file against a feed validator, such as the [W3C Feed Validation Service](https://validator.w3.org/feed/) to make sure that the output was good.
+Place the file in your src directory (give it a `.njk` extension). For example: src/feed.njk or src/feed.json. It will be transformed into a `feed.xml` (or `feed.json` if you’re using the JSON variant) file at the root of your website when Eleventy builds it. It can then be useful to check the file against a feed validator, such as the [W3C Feed Validation Service](https://validator.w3.org/feed/) to make sure that the output was good.
 
 Ultimately your feed will be available at `https://yourwebsite.com/feed.xml` (or `https://yourwebsite.com/feed.json`)
 


### PR DESCRIPTION
Add specific instructions for the sample feed template filename and location.

The existing instructions are unclear as to exactly where to save the feed template file to, and what it should be named. 

It took two hours Googling and trying different options until figuring out that it's not "Place the file anywhere in your project" but "anywhere in the src directory". The existing docs don't say what this file should be named which could be confusing.