### PR TITLE
Reset layout data in rss.md example

### DIFF
--- a/src/docs/plugins/rss.md
+++ b/src/docs/plugins/rss.md
@@ -197,6 +197,7 @@ Copy and paste this template and modify the JSON metadata to match your feed’s
 {
   "permalink": "feed.json",
   "eleventyExcludeFromCollections": true,
+  "layout": "",
   "metadata": {
     "title": "My Blog about Boats",
     "subtitle": "I am writing about my experiences as a naval navel-gazer.",


### PR DESCRIPTION
I tried copy-pasting this example, and when I entered my output feed.xml file into the validator, I got an error:

> It looks like this is a web page, not a feed. I looked for a feed associated with this page, but couldn't find one. Please enter the address of your feed to validate.

I realized that what was happening was that my data cascade was applying a layout that wrapped the XML tag in my default HTML layout.

I've changed the example .njk file to add a line in the front matter that resets any layout data from the cascade.

Another option would be to add a warning or clarification to the text, but I thought this seemed like a straightforward way to prevent future readers from making my mistake.