### PR TITLE
Changes the URL for Kinsta

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -42,7 +42,7 @@ hosts:
     url: https://codeberg.page/
     screenshotSize: medium
   - name: Kinsta
-    url: https://kinsta.com/
+    url: https://kinsta.com/docs/eleventy-static-site-example/
     screenshotSize: medium
 clis:
   - name: Netlify CLI


### PR DESCRIPTION
The new URL is connected with the documentation on deploying Eleventy on Kinsta rather than just the homepage.