### PR TITLE
Create eleventy-plugin-atlasicons.json

### DIFF
--- a/src/_data/plugins/eleventy-plugin-atlasicons.json
+++ b/src/_data/plugins/eleventy-plugin-atlasicons.json
@@ -1,0 +1,5 @@
+{
+  "npm": "the npm package name of your plugin",
+  "author": "Your Twitter username",
+  "description": "The shortcode enables the embedding of atlas-icons as inline SVG icon into templates."
+}


### PR DESCRIPTION
The shortcode enables the embedding of feather-icons as inline SVG icon into templates.