### PR TITLE
fix: edit in GitHub link redirects branch

### DIFF
--- a/src/_data/config.js
+++ b/src/_data/config.js
@@ -1,7 +1,7 @@
 export default {
 	outdated: false,
 	prerelease: false,
-	githubEdit: "https://github.com/11ty/11ty-website/blob/master/",
+	githubEdit: "https://github.com/11ty/11ty-website/blob/main/",
 	now: new Date(),
 	env: process.env.NODE_ENV
 };


### PR DESCRIPTION
"Edit in GitHub" link for blogs go to `master` branch instead of `main`. GitHub silently redirects this to the correct branch, but it's good to be explicit.