### PR TITLE
Add new section to Quick Tip #004—Zero Maintenance Tag Pages for your Blog

### DIFF
--- a/src/docs/quicktips/tag-pages.md
+++ b/src/docs/quicktips/tag-pages.md
@@ -77,7 +77,7 @@ Now Eleventy will only generate a `/tags/personal/` template and `tech` will be 
 
 ## Include all Tag Pages in the `all` Collection
 
-By default, only the first page generated with pagination will be added to the `all` collection. Ordinarily, this is not a problem, but with how we are using pagination in this unconventional manner to generate Tag Pages, you will likely want each Tag Page to be added to the `all` collection (very helpful to later generate a sitemap.xml file). Pages must opt-in to this behavior by setting `addAllPagesToCollections` to `true` like this:
+By default, only the first page generated with pagination will be added to the `all` collection. Ordinarily, this is not a problem, but with how we are using pagination in this unconventional manner to generate Tag Pages, you will likely want each Tag Page to be added to the `all` collection (very helpful to later generate a sitemap.xml file). Pages must opt-in to change this behavior by setting `addAllPagesToCollections` to `true` like this:
 
 {% raw %}
 ```markdown

--- a/src/docs/quicktips/tag-pages.md
+++ b/src/docs/quicktips/tag-pages.md
@@ -75,6 +75,25 @@ permalink: /tags/{{ tag }}/
 
 Now Eleventy will only generate a `/tags/personal/` template and `tech` will be ignored.
 
+## Include all Tag Pages in collections.all
+
+By default, only the first page generated with pagination will be added to the `all` collection. Ordinarily, this is not a problem, but with how we are using pagination in this unconventional manner to generate Tag Pages, you will likely want each Tag Page to be added to the `all` collection (very helpful to later generate a sitemap.xml file). Pages must opt-in to this behavior by setting `addAllPagesToCollections` to `true` like this:
+
+{% raw %}
+```markdown
+---
+pagination:
+  addAllPagesToCollections: true
+  data: collections
+  size: 1
+  alias: tag
+  filter:
+    - tech
+permalink: /tags/{{ tag }}/
+---
+```
+{% endraw %}
+
 ## In Practice
 
 This is currently in use on the [`eleventy-base-blog` sample project](https://github.com/11ty/eleventy-base-blog). Check out source code in the [`tags.njk` template](https://github.com/11ty/eleventy-base-blog/blob/main/content/tags.njk) and [see a live demo](https://eleventy-base-blog.netlify.com/tags/another-tag/).

--- a/src/docs/quicktips/tag-pages.md
+++ b/src/docs/quicktips/tag-pages.md
@@ -75,7 +75,7 @@ permalink: /tags/{{ tag }}/
 
 Now Eleventy will only generate a `/tags/personal/` template and `tech` will be ignored.
 
-## Include all Tag Pages in collections.all
+## Include all Tag Pages in the `all` Collection
 
 By default, only the first page generated with pagination will be added to the `all` collection. Ordinarily, this is not a problem, but with how we are using pagination in this unconventional manner to generate Tag Pages, you will likely want each Tag Page to be added to the `all` collection (very helpful to later generate a sitemap.xml file). Pages must opt-in to this behavior by setting `addAllPagesToCollections` to `true` like this:
 


### PR DESCRIPTION
Adds a new section that addresses a common problem for those that use the tag pages tip but have problems with the pagination generated pages not showing up in the `all` collection.  This created a problem for me until I came across [this issue](https://github.com/11ty/eleventy/issues/253#issuecomment-462215277). 