### PR TITLE
Update pagination.md to mention alias

### DIFF
--- a/src/docs/pagination.md
+++ b/src/docs/pagination.md
@@ -93,6 +93,7 @@ In addition to the `pagination` object entries documented above, it also has:
 {
   data: "…", // the original string key to the dataset
   size: 1, // page chunk sizes
+  alias: "…", // the original string alias for pagination.items[0]
 
   // Cool URLs
   // Use pagination.href.next, pagination.href.previous, et al instead.


### PR DESCRIPTION
Alias is available in the `pagination` object, but seems to be undocumented. I'm not sure how often someone would want it, so have put it in the collapsed 'extra' section.