### PR TITLE
Create eleventy-plugin-future-post.json

### DIFF
--- a/src/_data/plugins/eleventy-plugin-future-post.json
+++ b/src/_data/plugins/eleventy-plugin-future-post.json
@@ -1,0 +1,5 @@
+{
+  "npm": "eleventy-plugin-future-post",
+  "author": "johnwargo",
+  "description": "Allows you to set a future publishing date for one or more posts and not generate (publish) them until you build the site after the selected date. Based on the Eleventy Base Blog Drafts plugin."
+}


### PR DESCRIPTION
This is an Eleventy Plugin that allows you to set a future publishing date for one or more posts and not generate (publish) them until you build the site after the selected date.

The [Eleventy Base Blog](https://github.com/11ty/eleventy-base-blog) project has a drafts feather that allows you to work on a post within an Eleventy project without publishing it. You essentially assign a draft state to the post and Eleventy doesn't publish it during the build process until you remove the draft state.

For my use case, I wanted something different, I didn't want to manage the state of the document, I wanted the document to publish based on metadata in the post (the post date property).  Described in better detail here: https://johnwargo.com/posts/2024/hiding-future-posts-eleventy/