### PR TITLE
Add eleventy-plugin-gpt4all to plugins

### DIFF
--- a/src/_data/plugins/eleventy-plugin-gpt4all.json
+++ b/src/_data/plugins/eleventy-plugin-gpt4all.json
@@ -1,0 +1,5 @@
+{
+    "npm": "eleventy-plugin-gpt4all",
+    "description": "Use generative ai to generate your statics."
+}
+  


### PR DESCRIPTION
Here's the plugin on
- Github: https://github.com/doug-wade/eleventy-plugin-gpt4all
- npm: https://www.npmjs.com/package/eleventy-plugin-gpt4all

I followed the instructions I found here: https://github.com/11ty/11ty-website/tree/main/src/_data/plugins#readme