### PR TITLE
add xmit to classic web hosts

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -75,6 +75,9 @@ classicHosts:
   - name: Cloudflare Direct Upload
     url: https://developers.cloudflare.com/pages/get-started/direct-upload/#drag-and-drop
     screenshotSize: medium
+  - name: xmit
+    url: https://xmit.co/
+    screenshotSize: medium
 webides:
   - name: Glitch
     url: https://glitch.com/


### PR DESCRIPTION
Recently launched https://xmit.co and figured it'd be worth adding to 11ty's list.