### PR TITLE
Add redirect to is-land plugin from partial-hydration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -104,6 +104,12 @@ to = "/docs/plugins/fetch/"
 status = 301
 force = true
 
+[[redirects]]
+from = "/docs/plugins/partial-hydration/"
+to = "/docs/plugins/is-land/"
+status = 301
+force = true
+
 [[headers]]
 for = "/api/*"
 


### PR DESCRIPTION
Both 11ty.dev and zachleat.com link to:
https://www.11ty.dev/docs/plugins/partial-hydration/

in several places. Which is now: 
https://www.11ty.dev/docs/plugins/is-land/

This seems to be the easiest fix, unless I am missing something.