### PR TITLE
add eleventy-plugin-vento

### DIFF
--- a/src/_data/plugins/eleventy-plugin-vento.json
+++ b/src/_data/plugins/eleventy-plugin-vento.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-vento",
+	"author": "noelforte",
+	"description": "adds support for the Vento templating language."
+}


### PR DESCRIPTION
This pull request adds a listing for a plugin I wrote to add support for Vento (`.vto`) template files to Eleventy. 

Vento is a new JS-template language that aims to pick up where languages like Nunjucks left off. While targeted at deno, it runs great in node.js as well. More info here: https://vento.js.org/

Thanks y'all!