### PR TITLE
Add eleventy-plugin-less to community plugins page

### DIFF
--- a/src/_data/plugins/eleventy-plugin-less.json
+++ b/src/_data/plugins/eleventy-plugin-less.json
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-less",
+	"author": "nfriedly",
+	"description": "Compiles Less stylesheets to CSS"
+}


### PR DESCRIPTION
Add https://www.npmjs.com/package/eleventy-plugin-less to https://www.11ty.dev/docs/plugins/community/