### PR TITLE
Nudge Nordhealth logotext and remove unused styling

### DIFF
--- a/src/_includes/components/supporters.css
+++ b/src/_includes/components/supporters.css
@@ -72,7 +72,7 @@
 	justify-content: center;
 }
 .supporters-gold-nordhealth {
-	flex-grow: 1.8;
+	translate: 0 0.375em
 }
 .supporters-gold-cloudcannon {
 	flex-grow: 1.7;
@@ -92,12 +92,6 @@
 @media (prefers-color-scheme: dark) {
 	.supporters-gold-transloadit svg {
 		color: #fff;
-	}
-}
-@media (min-width: 55em) {
-	/* 880px */
-	.supporters-gold-nordhealth {
-		flex-grow: 1.3;
 	}
 }
 


### PR DESCRIPTION
This aims to optically align the Nordhealth logo with the Transloadit logo and remove some unused styles. For `flex-grow` to take effect, the parent element needs to have `display: flex`. It is currently `display: grid`.