### PR TITLE
Add WebC bed, a minimal starter

### DIFF
--- a/src/_data/starters/webcbed.json
+++ b/src/_data/starters/webcbed.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/rdela/webcbed",
+	"name": "WebC bed",
+	"description": "Minimal Eleventy WebC Starter",
+	"author": "rdela",
+	"demo": "https://webcbed.netlify.app/"
+}


### PR DESCRIPTION
Add WebC bed, a minimal Eleventy WebC starter.

url: https://github.com/rdela/webcbed
demo: https://webcbed.netlify.app/