### PR TITLE
remove deprecated starter eleventy-card

### DIFF
--- a/src/_data/starters/eleventy-card.json
+++ b/src/_data/starters/eleventy-card.json
@@ -1,8 +1,0 @@
-{
-	"url": "https://github.com/sira313/eleventy-card",
-	"name": "Eleventy-card",
-	"description": "Clean and minimalist starter website for artists/photographers to post their artwork in a masonry layout and blog separately in a very simple layout. Created with Bulma CSS and Feather Icons.",
-	"author": "Apoxicam",
-	"demo": "https://eleventy-card.netlify.app/",
-	"excludedFromLeaderboards": true
-}


### PR DESCRIPTION
I wanted to remove my deprecated starter `eleventy-card`, and I've committed the replacement [twcarty](https://github.com/11ty/11ty-website/blob/main/src/_data/starters/twcarty.json)