### PR TITLE
Fix inconsistent package reccomendation for TOML parsing

### DIFF
--- a/src/docs/data-custom.md
+++ b/src/docs/data-custom.md
@@ -78,7 +78,7 @@ module.exports = (eleventyConfig) => {
 
 ### TOML
 
-Here we’re using the [`toml` package](https://www.npmjs.com/package/toml). Don’t forget to `npm install toml`.
+Here we’re using the [`@iarna/toml` package](https://www.npmjs.com/package/@iarna/toml). Don’t forget to `npm install @iarna/toml`.
 
 {% codetitle ".eleventy.js" %}
 


### PR DESCRIPTION
I was adding TOML data parsing to an 11ty site when I noticed that a different package was reccomended in the text to the one used in the example code.

I'm assuming (based on 4e50f1a) that `@iarna/toml` is the correct one, so this PR changes the text to match.