### PR TITLE
Fix documentation of `setEventEmitterMode`

### DIFF
--- a/src/docs/events.md
+++ b/src/docs/events.md
@@ -140,11 +140,11 @@ export default function(eleventyConfig) {
 
 ## Emitter Modes
 
-Currently Eleventy triggers event callbacks in parallel. If you need to run the event callbacks sequentially, you can do so with the `setEmitterMode` configuration API method. Related [GitHub #3415](https://github.com/11ty/eleventy/issues/3415).
+Currently Eleventy triggers event callbacks in parallel. If you need to run the event callbacks sequentially, you can do so with the `setEventEmitterMode` configuration API method. Related [GitHub #3415](https://github.com/11ty/eleventy/issues/3415).
 
 {% set codeContent %}
 export default function(eleventyConfig){
-	eleventyConfig.setEmitterMode("sequential");
+	eleventyConfig.setEventEmitterMode("sequential");
 }
 {% endset %}
 {% include "snippets/configDefinition.njk" %}


### PR DESCRIPTION
Tried using `eleventyConfig.setEmitterMode`, and the build failed due to it not being a function. Turns out, it is actually called `setEventEmitterMode` (see [UserConfig.js](https://github.com/11ty/eleventy/blob/8675d68ec049bb683b0b09f42bd2703909eb0e53/src/UserConfig.js#L265)).