### PR TITLE
Fix yarn exec command usage

### DIFF
--- a/src/docs/index.webc
+++ b/src/docs/index.webc
@@ -246,7 +246,7 @@ Use `--serve` to start up a hot-reloading local web server.
 	</div>
 	<div id="quickstart-run-5-yarn" role="tabpanel">
 		<syntax-highlight language="bash">
-			yarn exec eleventy --serve
+			yarn exec eleventy -- --serve
 		</syntax-highlight>
 	</div>
 </seven-minute-tabs>


### PR DESCRIPTION
Closes https://github.com/11ty/eleventy/issues/3522. `yarn exec` consumes the `--serve` option and does not pass it to Eleventy as an argument:

Passing `yarn exec` the `echo` command and then the `test` argument results in `test` being echoed.

```
$ yarn exec echo test
yarn exec v1.22.22
test
✨  Done in 0.03s.
```

Passing `yarn exec` the `echo` command and then the `--test` argument/option/flag results in nothing being echoed.

```
$ yarn exec echo --test
yarn exec v1.22.22

✨  Done in 0.03s.
```

This can however be fixed by using `--` to designate the end of options and the remainder are interpreted as arguments:

```
$ yarn exec echo -- --test
yarn exec v1.22.22
--test
✨  Done in 0.02s.
```
