### PR TITLE
Update index.webc with more detailed guidance

### DIFF
--- a/src/docs/index.webc
+++ b/src/docs/index.webc
@@ -173,7 +173,10 @@ echo '# Heading' > README.md
 echo '<!doctype html><title>Page title</title><p>Hi</p>' | out-file -encoding utf8 'index.html'
 echo '# Heading' | out-file -encoding utf8 'README.md'
 </syntax-highlight>
-		<p>If the <code>out-file</code> command is not available in your Windows Terminal window (it’s PowerShell specific), use the Cross Platform method instead.</p>
+		<p>
+		If the <code>out-file</code> command is not available in your Windows Terminal window (it’s PowerShell specific), use the Cross Platform method instead.
+		When you use PowerShell in windows, you may need to change the execution policy using <code>Set-ExecutionPolicy Unrestricted</code> to ensure the smooth progress of the subsequent steps.
+		</p>
 	</div>
 	<div id="quickstart-os-all" role="tabpanel">
 <syntax-highlight language="bash">


### PR DESCRIPTION
At the 4th step of the document, the  out-file command in windows is Power Shell specific. But Power Shell has a default execution policy to restrict the running of JavaScript, which would cause an error when running Eleventy in the next step. If a solution can be provided here(use a command to set the execution policy), the whole experience of trying running Eleventy would be smoother and more beginner-friendly.