### PR TITLE
Fix Author Permalink Structure for Consistency and SEO on 11ty Site

### DIFF
--- a/src/authors/author-pages.md
+++ b/src/authors/author-pages.md
@@ -5,7 +5,7 @@ pagination:
   alias: author
   resolve: values
   generatePageOnEmptyData: true
-permalink: "/authors/{{ author.name | slug }}/"
+permalink: "/authors/{{ author.name | slugify }}/"
 excludeFromSearch: true
 layout: layouts/docs.njk
 ---

--- a/src/authors/author-pages.md
+++ b/src/authors/author-pages.md
@@ -5,7 +5,7 @@ pagination:
   alias: author
   resolve: values
   generatePageOnEmptyData: true
-permalink: "/authors/{{ author.name }}/"
+permalink: "/authors/{{ author.name | slug }}/"
 excludeFromSearch: true
 layout: layouts/docs.njk
 ---


### PR DESCRIPTION
This pull request fixes an issue with the author permalink structure on the 11ty website, caused by differences in case sensitivity between Netlify and Vercel. Netlify handles URLs in a case-tolerant manner, automatically forcing them to lowercase, which ensured that links like 

- https://www.11ty.dev/authors/MartyNZ/ [200]
- https://www.11ty.dev/authors/ItsMeAra/ [200]

worked seamlessly. However, on Vercel, URLs are case-sensitive, which led to inconsistencies and broken links when author slugs were not uniformly lowercase.

Current https://www.11ty.dev/authors/ page contains all links in lowercase format like this

- https://www.11ty.dev/authors/martynz/ [404]
- https://www.11ty.dev/authors/itsmeara/ [404]

To resolve this, the author permalink structure has been updated to enforce lowercase formatting using a slug filter. This change ensures all author URLs are consistently lowercase, preventing broken links and ensuring proper routing on Vercel’s deployment environment.

By standardizing URLs, this update enhances both user experience and SEO, ensuring predictable, functional, and clean author page links across the site.