### PR TITLE
Update eleventy-plugin-podcaster.json

### DIFF
--- a/src/_data/plugins/eleventy-plugin-podcaster.json
+++ b/src/_data/plugins/eleventy-plugin-podcaster.json
@@ -1,5 +1,5 @@
 {
   "npm": "eleventy-plugin-podcaster",
-  "author": "nathanbottomley",
+  "author": "nathan-bottomley",
   "description": "Helps you create a feed and a website for your podcast."
 }


### PR DESCRIPTION
Changed "author" field to be my GitHub usernanme.

(My Twitter/X handle is the same as someone else's GitHub username, and so it's their avatar that currently appears on the Eleventy Community Plugins page instead of mine.