### PR TITLE
Add missing step to Deploy an Eleventy project to GitHub pages mini-tutorial

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -191,6 +191,15 @@ Includes persisted cache across builds. Using [`peaceiris/actions-gh-pages`](htt
 <ol>
 <li>Go to your repository’s Settings on GitHub.</li>
 <li>In the GitHub Pages section change:<ul><li>Source: <code>Deploy from a branch</code></li><li>Branch: <code>gh-pages/(root)</code></li></ul></li>
+<li>Add "build-ghpages" command to your <details><summary><code>package.json</code> scripts section</summary>
+
+```json
+"scripts": {
+  "build-ghpages": "npx @11ty/eleventy --pathprefix=/your-repo-name/",
+}
+```
+
+</details></li>
 <li>Create a new GitHub workflow file in <details><summary><code>.github/workflows/deploy-to-ghpages.yml</code></summary>
 
 {% raw %}


### PR DESCRIPTION
This PR solves the issue seen in #1766 where the mini-tutorial doesn't describe the build-ghpages npm script that is used by the workflow.