### PR TITLE
Update data-global.md

### DIFF
--- a/src/docs/data-global.md
+++ b/src/docs/data-global.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 
 Global data is [data](/docs/data/) that is exposed to every template in an Eleventy project.
 
-One way to create global data is through <dfn>global data files</dfn>: JSON and JavaScript files placed inside of the <dfn>global data folder</dfn>. The global data folder is placed inside the project's input directory (set by the [`dir.input` configuration option](/docs/config/#input-directory)), and the name of the global data folder is set by the [`dir.data` configuration option](/docs/config/#directory-for-global-data-files) (`_data` by default). All `*.json` and `module.exports` values from [`*.js` files](/docs/data-js/) in this directory will be added into a global data object available to all templates.
+One way to create global data is through <dfn>global data files</dfn>: JSON and JavaScript files placed inside of the <dfn>global data folder</dfn>. The global data folder is placed inside the project's input directory (set by the [`dir.input` configuration option](/docs/config/#input-directory)), and the name of the global data folder is set by the [`dir.data` configuration option](/docs/config/#directory-for-global-data-files) (`_data` by default). All `*.json` and `module.exports` values from [`*.js` files](/docs/data-js/) in this directory will be added into a global data object available to all templates. The name and location of these files will inform the keys in the data object structure where they can be accessed. Note that this means [computed data](/docs/data-computed/) must be in a file called `eleventyComputed.js`.
 
 You may also be interested in [config global data](/docs/data-global-custom/){% addedin "1.0.0" %}, which is another way to add global data to every template in an Eleventy project.
 


### PR DESCRIPTION
Making it clear in the documentation that the filename is the object key that is used in the 11ty data object rather than relying on the Example section to communicate that.