### PR TITLE
Update Github Pages Mini Tutorial to be consistent with documentation

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -232,7 +232,7 @@ jobs:
           key: ${{ runner.os }}-eleventy-fetch-cache
 
       - run: npm install
-      - run: npm run build-ghpages
+      - run: npm run build
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Corrected the `run` command in the Github Pages Mini Tutorial to be consistent with the npm script section earlier on the page