### PR TITLE
fix: Correct broken hash link

### DIFF
--- a/src/docs/shortcodes.md
+++ b/src/docs/shortcodes.md
@@ -104,7 +104,7 @@ Read more about using paired shortcodes on the individual Template Language docu
 A few Eleventy-specific data properties are available to shortcode callbacks.
 
 - `this.page` {% addedin "0.11.0" %} (Learn about [`page`](/docs/data-eleventy-supplied.md#page-variable))
-- `this.eleventy` {% addedin "2.0.0-canary.5" %} (Learn about [`eleventy`](/docs/data-eleventy-supplied.md##eleventy-variable))
+- `this.eleventy` {% addedin "2.0.0-canary.5" %} (Learn about [`eleventy`](/docs/data-eleventy-supplied.md#eleventy-variable))
 - `this.env` (Nunjucks-specific) {% addedin "3.0.0-canary.5" %}
 - `this.ctx` (Nunjucks-specific) {% addedin "3.0.0-canary.5" %}
 


### PR DESCRIPTION
I haven't changed the last line, so no idea why it's marked as _modified_.