### PR TITLE
fix: correct typos in documentation

### DIFF
--- a/src/docs/permalinks.md
+++ b/src/docs/permalinks.md
@@ -186,7 +186,7 @@ Writes to `_site/2016/01/01/index.html`. There are a variety of ways that the pa
 
 <div id="warning-about-yaml-objects"></div>
 
-{% callout "warn", "md" %}**YAML Pitall:** If your permalink uses template syntax, make sure that you use quotes! Without quotes YAML may try to parse this as an object if the first character is a `{`, for example `permalink: {% raw %}{{ page.filePathStem }}{% endraw %}.html`. This is a [**common pitfall**](/docs/pitfalls/).{% endcallout %}
+{% callout "warn", "md" %}**YAML Pitfall:** If your permalink uses template syntax, make sure that you use quotes! Without quotes YAML may try to parse this as an object if the first character is a `{`, for example `permalink: {% raw %}{{ page.filePathStem }}{% endraw %}.html`. This is a [**common pitfall**](/docs/pitfalls/).{% endcallout %}
 
 {% codetitle "YAML", "Syntax" %}
 

--- a/src/docs/plugins/image-webc.md
+++ b/src/docs/plugins/image-webc.md
@@ -22,7 +22,7 @@ excludeFromSidebar: true
 
 {% addedin "Image v3.1.0" %} Eleventy Image now provides a built-in `<eleventy-image>` WebC component for use in your Eleventy project.
 
-Using Eleventy Image in [WebC](/docs/languages/webc.md) offers all the same great benefits you’re used to from Eleventy Image with an intuitive declarative HTML-only developer experience. WebC components work in `*.webc` files. For similar functionality in other template formats, use the the [Liquid/Nunjucks/JavaScript shortcodes](./image-shortcodes.md) above (or even `<eleventy-image>` with the [Render plugin](/docs/plugins/render.md)).
+Using Eleventy Image in [WebC](/docs/languages/webc.md) offers all the same great benefits you’re used to from Eleventy Image with an intuitive declarative HTML-only developer experience. WebC components work in `*.webc` files. For similar functionality in other template formats, use the [Liquid/Nunjucks/JavaScript shortcodes](./image-shortcodes.md) above (or even `<eleventy-image>` with the [Render plugin](/docs/plugins/render.md)).
 
 ### Configuration
 


### PR DESCRIPTION
Resolve minor typographical errors in Image plugin and Permalinks documentation. Adjusted duplicated word and fixed a misspelling in the YAML callout block.

(This commit message was AI-generated.)