### PR TITLE
Create eleventy-plugin-llms-txt

### DIFF
--- a/src/_data/plugins/eleventy-plugin-llms-txt
+++ b/src/_data/plugins/eleventy-plugin-llms-txt
@@ -1,0 +1,5 @@
+{
+	"npm": "eleventy-plugin-llms-txt",
+	"author": "LostInBrittany",
+	"description": "An Eleventy plugin that generates a `llms.txt` file to expose your site's content to Large Language Models (LLMs) in a structured format."
+}


### PR DESCRIPTION
An Eleventy plugin that generates a `llms.txt` file to expose your site's content to Large Language Models (LLMs) in a structured format.