### PR TITLE
Add a note about the functioning of webc:setup

### DIFF
--- a/src/docs/languages/webc.md
+++ b/src/docs/languages/webc.md
@@ -708,6 +708,10 @@ You can also specify an attribute value to `webc:scoped` to hard code your own c
 
 This is similar to using [JavaScript as a custom Eleventy Front Matter type](/docs/data-frontmatter-customize/#example-use-javascript-in-your-front-matter), although data in `webc:setup` is scoped to the component and _does not_ flow back up in the Data Cascade.
 
+{% callout "info", "md" %}
+**Note:** This JavaScript is run _only once_ per build, even if the component is used in multiple instances. Therefore, there is no access inside the `<script webc:setup>` tag to instance-specific data such as attributes, props, or slots.
+{% endcallout %}
+
 {% codetitle "components/my-component.webc" %}
 
 ```html


### PR DESCRIPTION
I believe this note is accurate to how `webc:setup` works, based on [this message from a Discord user](https://discord.com/channels/741017160297611315/1356938250886840340/1357051979872079967):

> webc:setup only runs once for the whole project  - it doesn't have access to slots or anything else specific to some instance of the component. (But you can define functions there, then pass them the local data. I'd guess that slots could be passed in too, but I'm not sure if that's only available in webc:type="js".)

If this is indeed a correct understanding, I think this note would be helpful to new WebC coders in understanding the limitations and best practices with `webc:setup`