### PR TITLE
added Orbiter as an option for classic web hosts

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -75,6 +75,9 @@ classicHosts:
   - name: Tiiny Host
     url: https://tiiny.host
     screenshotSize: medium
+  - name: Orbiter
+    url: https://orbiter.host
+    screenshotSize: medium
 webides:
   - name: Glitch
     url: https://glitch.com/


### PR DESCRIPTION
Wrote a guide for this a while back, but figured it might make sense to have Orbiter as an option listed in the 11ty docs. 

[https://orbiter.host/blog/how-to-build-and-host-an-11ty-site](https://orbiter.host/blog/how-to-build-and-host-an-11ty-site)