### PR TITLE
Add Open Search support

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -430,6 +430,7 @@ ${text.trim()}
 		"src/css/fonts/BenchNine-Bold-kern-latin.woff2": "css/fonts/benchnine-bold.woff2",
 		"src/css/fonts/RobotoMono-Regular-kern-latin.woff2": "css/fonts/robotomono-regular.woff2",
 		"src/css/fonts/RobotoMono-Regular-kern-latinext.woff2": "css/fonts/robotomono-regular-ext.woff2",
+		"src/opensearch.xml": "opensearch.xml",
 	});
 
 	eleventyConfig.addPassthroughCopy({

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -72,6 +72,7 @@ let eleventyComputed = {
 {%- if feedTitle and feedUrl %}
 		<link rel="alternate" href="{{ feedUrl }}" title="{{ feedTitle }}" type="application/atom+xml">
 {%- endif %}
+		<link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Eleventy">
 
 {# Not currently used:
 {% include 'components/announcement.css' %}

--- a/src/opensearch.xml
+++ b/src/opensearch.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription
+	xmlns="http://a9.com/-/spec/opensearch/1.1/"
+	xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+	<ShortName>11ty</ShortName>
+	<LongName>Eleventy</LongName>
+	<Description>Search for things on the Eleventy website</Description>
+	<InputEncoding>UTF-8</InputEncoding>
+	<!-- <Image width="16" height="16"
+	type="image/png">https://www.11ty.dev/img/favicon-16.png</Image> -->
+	<Image width="96" height="96" type="image/png">https://www.11ty.dev/img/favicon.png</Image>
+	<Url type="text/html" method="get" template="https://www.11ty.dev/docs/search/?q={searchTerms}" />
+	<Url type="application/opensearchdescription+xml" rel="self"
+		template="https://www.11ty.dev/opensearch.xml" />
+	<moz:SearchForm>https://www.11ty.dev/</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Hey,

I thought it would be cool to add support for [Open Search](https://developer.mozilla.org/en-US/docs/Web/XML/Guides/OpenSearch). It's an open standard that (some) browsers use to let you search a website directly. In Firefox it works like this:

0. Add the plugin by right-clicking on the url in the search bar
1. type "11ty"
2. press [tab]
3. type a query
4. press [enter] 
5. the search goes directly to the `11ty.dev/docs/search?q=...`

Chrome used to have support for this but since removed it, Safari sort-of supports it. You have to visit the website and use the search and it will magically start suggesting 11ty search when you include _some_ relevant words based on some heuristic.

I'm in no way wed to this implementation, it could use a look from someone more familiar with the codebase. Some thoughts/questions:

- I added the new `opensearch.xml` file and updated an existing `passthroughCopy` to add this to the root of the output directory. We might not want the file to go there if there is a folder you'd prefer.
- The spec reccomends a 16x16 icon, but seems to work ok with the existin 96x96 version. I commented the 16x16 one out for now.
- It would be better to template the `opensearch.xml` file with 11ty data but I didn't want to set this up and complicate things.
- You might also want to change the copy within `opensearch.xml`, I just made a best-guess.
- I wasn't too sure where abouts in the `<head>` to link for this, I went for the "feeds" section?

Let me know what you think,
Rob