### PR TITLE
docs: add CloudRay to Deployment Guide

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -49,6 +49,9 @@ hosts:
   - name: Sourcehut Pages
     url: https://srht.site/
     screenshotSize: medium
+  - name: CloudRay
+    url: https://cloudray.io/articles/how-to-deploy-your-eleventy-website
+    screenshotSize: medium
 classicHosts:
   - name: Vercel CLI
     url: https://vercel.com/cli


### PR DESCRIPTION
This PR adds [CloudRay](https://cloudray.io/) Deployment Guide. CloudRay is a centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.