### PR TITLE
Fix: broken hash links to Opt-out of using .gitignore

### DIFF
--- a/src/docs/ignores.md
+++ b/src/docs/ignores.md
@@ -43,7 +43,7 @@ You can also use the new [Preprocessor Configuration API](/docs/config-preproces
 
 ### `.gitignore` entries
 
-Paths listed in your project’s `.gitignore` file are automatically ignored. You can [opt-out of this behavior](#opt-out-of-using-.gitignore).
+Paths listed in your project’s `.gitignore` file are automatically ignored. You can [opt-out of this behavior](#opt-out-of-using-gitignore).
 
 ### `node_modules` {% addedin "1.0.0" %}
 

--- a/src/docs/watch-serve.md
+++ b/src/docs/watch-serve.md
@@ -58,7 +58,7 @@ export default function(eleventyConfig) {
 
 ### `.gitignore`
 
-Eleventy will ignore changes to files or folders listed in your `.gitignore` file by default, [unless `setUseGitIgnore` is turned off](/docs/ignores/#opt-out-of-using-.gitignore).
+Eleventy will ignore changes to files or folders listed in your `.gitignore` file by default, [unless `setUseGitIgnore` is turned off](/docs/ignores/#opt-out-of-using-gitignore).
 
 ### Configuration API {% addedin "2.0.0-canary.18" %}
 


### PR DESCRIPTION
The generated anchor id does not include the `.` in “Opt-out of using .gitignore”

Fix the hash in links by removing the `.` in the same page anchor and the link on watch-serve

🎈🫶