### PR TITLE
Update inline-js.md | Fix jsmin filter example to use correct async syntax

### DIFF
--- a/src/docs/quicktips/inline-js.md
+++ b/src/docs/quicktips/inline-js.md
@@ -20,14 +20,14 @@ Add the following `jsmin` filter to your Eleventy Config file:
 import { minify } from "terser";
 
 export default function (eleventyConfig) {
-	eleventyConfig.addFilter("jsmin", async function (code, callback) {
+	eleventyConfig.addFilter("jsmin", async function (code) {
 		try {
 			const minified = await minify(code);
-			callback(null, minified.code);
+			return minified.code;
 		} catch (err) {
 			console.error("Terser error: ", err);
 			// Fail gracefully.
-			callback(null, code);
+			return code;
 		}
 	});
 };


### PR DESCRIPTION
The `jsmin` filter uses a callback that doesn't work with the 11ty's filter

**Problem:**
When I use the the example as it is from the docs, the filter throws an error at runtime saying `TypeError: callback is not a function` (because it's undefined)

**Testing:**
Verified that:
- The original docs example fails in a new and empty 11ty v3.1.2 project (by default it uses luiquid but I tested with njk jusjt to be sure)
- The corrected async/await version works as expected
- The filter registers properly and minifies JavaScript code successfully

**Solution:**
Updated the example to use `return` with async/await instead of the callback pattern.