### PR TITLE
mustache.md to reference mustache instead of ejs

### DIFF
--- a/src/docs/languages/mustache.md
+++ b/src/docs/languages/mustache.md
@@ -16,7 +16,7 @@ You can override a `.mustache` file’s template engine. Read more at [Changing 
 
 ## Installation
 
-The `ejs` templating language was moved out of Eleventy core in v3 and now requires a plugin installation.
+The `.mustache` templating language was moved out of Eleventy core in v3 and now requires a plugin installation.
 
 * [`11ty/eleventy-plugin-template-languages` on GitHub](https://github.com/11ty/eleventy-plugin-template-languages)
 


### PR DESCRIPTION
Removed incorrect reference to EJS on mustache.md page.