### PR TITLE
docs: update JavaScript runtime documentation with 'deno x' usage

### DIFF
--- a/src/docs/javascript-runtime.webc
+++ b/src/docs/javascript-runtime.webc
@@ -38,3 +38,10 @@ deno --allow-all npm:@11ty/eleventy --serve
 </syntax-highlight>
 
 <p>Read about our plans to <a href="https://github.com/11ty/eleventy/issues/3278">move away from <code>--allow-all</code> on #3278</a>.</p>
+
+<p>If you're on <a href="https://deno.com/blog/v2.6">Deno 2.6</a> or higher, you can also use <code>deno x</code>:</p>
+
+<syntax-highlight language="shell">
+deno x @11ty/eleventy
+deno x @11ty/eleventy --serve
+</syntax-highlight>


### PR DESCRIPTION
Added instructions for using `deno x` with Eleventy. I have tested and this works nicely.

In my opinion, this brings the complexity level down for using the Deno runtime with Eleventy, providing the equivalent experience for Node/npx users. _Although_, it does also pull the rug over all the work you've been doing to move away from `--allow-all` permissions. Totally understand if you don't want to merge this!

I chose to use the more verbose `deno x` than the `dx` command, as not all Deno users will have installed the alias.

From the [Deno 2.6 announcement](https://deno.com/blog/v2.6):
>Deno 2.6 introduces a new tool, dx, that is an equivalent to npx and is a convenient way to run binaries from npm and JSR packages.


> `dx` works similarly to `deno run`, but with the following differences:
> 
> - `dx` defaults to `--allow-all` permissions, unless another permission flag is passed
> - `dx` prompts you before downloading a package
> - `dx` runs lifecycle scripts automatically if you accept the aforementioned prompt
> - `dx` defaults to `npm:<package_name>` unless otherwise specified
> - `dx` errors if you try to use it to run a local file
> 
> With the addition of `dx`, users should find it easier to run package binaries in already known fashion. You can enjoy the convenience of `npx` while leveraging Deno’s robust security model and performance optimizations.