### PR TITLE
Fix import path of the config's TypeScript type definitions

### DIFF
--- a/src/docs/config.md
+++ b/src/docs/config.md
@@ -479,7 +479,7 @@ This will now include a `data` property in your JSON output that includes the `p
 This may enable some extra autocomplete features in your IDE (where supported).
 
 {% set codeContent %}
-/** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
+/** @param {import("@11ty/eleventy/UserConfig").default} eleventyConfig */
 export default function (eleventyConfig) {
 	// …
 };


### PR DESCRIPTION
According to the `package.json` of eleventy, `UserConfig` is exported from `@11ty/eleventy/UserConfig`.

See https://github.com/11ty/eleventy/blob/v3.1.2/package.json#L16-L18 and https://github.com/11ty/eleventy/blob/v3.1.2/src/UserConfig.js#L1339.