### PR TITLE
Adding ReallySimpleDocs

### DIFF
--- a/src/_data/starters/reallysimpledocs.json
+++ b/src/_data/starters/reallysimpledocs.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/hunvreus/reallysimpledocs",
+	"name": "ReallySimpleDocs",
+	"description": "A really simple documentation template built with 11ty and Tailwind.",
+	"author": "hunvreus",
+	"demo": "https://reallysimpledocs.com"
+}


### PR DESCRIPTION
Adding ReallySimpleDocs (https://reallysimpledocs.com), a documentation template built with 11ty.