### PR TITLE
Add Eleventy Webring to starter projects

### DIFF
--- a/src/_data/starters/eleventy-webring.json
+++ b/src/_data/starters/eleventy-webring.json
@@ -1,0 +1,6 @@
+{
+	"url": "https://github.com/querkmachine/eleventy-webring",
+	"name": "Eleventy Webring",
+	"description": "Eleventy-based webring creator for the 90s kids.",
+	"author": "querkmachine"
+}


### PR DESCRIPTION
Adds [Eleventy Webring](https://github.com/querkmachine/eleventy-webring), a rather basic boilerplate for making webrings like it's the 90s/early 2000s again, but with Eleventy, so it doesn't require any backend programming languages or client-side JavaScript to work. 

Doesn't have a fixed demo (it's rather difficult to demo a multi-site webring) but https://noodle-r.ing/ is one example of it in use. 