### PR TITLE
Suggest Liquid as a template language

### DIFF
--- a/src/docs/languages.md
+++ b/src/docs/languages.md
@@ -8,7 +8,7 @@ eleventyNavigation:
 
 Eleventy’s super power is that it is built on an extensible architecture that can work with one or more template languages in the same project.
 
-Not sure which one to choose? [Nunjucks](/docs/languages/nunjucks/) is a popular option for building creating HTML pages, with plenty of examples in this documentation.
+Not sure which one to choose? [Liquid](/docs/languages/liquid/) is a popular option for building creating HTML pages, with plenty of examples in this documentation.
 
 <style>
 .elv-page-toc-asterisk:before,


### PR DESCRIPTION
- Refs https://github.com/11ty/11ty-website/issues/1899

I find the "Template Languages" page frustrating because it's a lot of unweighted choices: to a new user, it's just a bunch of random names with no hint about which one to use and what makes them different.

This is a first, minimal, hopefully not _too_ controversial change.

This now recommends **Liquid** because it's the default for Markdown and HTML content, the NPM module is actively maintained, and there are many examples of Liquid templates in the documentation.

---

I'm planning on following this up with PRs to:

- Add an excerpt to each template language to make it clear on the same page what it does, and split the 'core' plugins from the 'installable' plugins.
- Add a summary of each language at the top of the language pages.