### PR TITLE
Add introductory information to Sass template language

### DIFF
--- a/src/docs/languages/sass.md
+++ b/src/docs/languages/sass.md
@@ -11,6 +11,10 @@ logoImage: "/img/logos/sass.svg"
 
 <!-- {% tableofcontents "open" %} -->
 
+[Sass](https://sass-lang.com/) is a CSS extension language: it implements extra features not found in CSS directly. You can use Sass as a template language and 11ty will transform it into CSS for you.
+
+You don't have to use Sass to style your site: [Eleventy supports normal CSS as well as other assets assets.](/docs/assets) Also, consider that CSS has added many of the features of Sass, like nested styles and variables, so it's no longer as necessary to use Sass.
+
 | Eleventy Short Name | File Extension | npm Package |
 | ------------------- | -------------- | ----------- |
 | `scss`          | `.scss`         | [`sass`](https://www.npmjs.com/package/sass) |


### PR DESCRIPTION
<img width="1714" height="814" alt="CleanShot 2026-01-28 at 20 18 53@2x" src="https://github.com/user-attachments/assets/05db4ed8-90f3-48cc-b329-5f55bf95f0ac" />

Per #1899, I think the documentation pages for templates are lacking introductory information. This adds some, starting with the page about the Sass template language.