### PR TITLE
Template language prose batch

### DIFF
--- a/src/docs/languages/ejs.md
+++ b/src/docs/languages/ejs.md
@@ -7,6 +7,8 @@ eleventyNavigation:
 layout: layouts/langs.njk
 ---
 
+[EJS](https://ejs.co/), short for _Embedded JavaScript_, is a template language that emphasizes the use of plain JavaScript instead of having its own template syntax. It can be really convenient if you're fluent in JavaScript. As opposed to languages like [Mustache](/docs/languages/mustache/) that bill themselves as 'logic-less', EJS lets you use as much logic as you'd like.
+
 {% tableofcontents "open" %}
 
 | Eleventy Short Name | File Extension | npm Package                                |

--- a/src/docs/languages/haml.md
+++ b/src/docs/languages/haml.md
@@ -7,6 +7,10 @@ eleventyNavigation:
 layout: layouts/langs.njk
 ---
 
+[HAML](https://haml.info/), or "HTML abstraction markup language," is a template language that lets you write HTML in a very terse style. The language was initially popular in the Ruby programming language, and was ported to JavaScript.
+
+If you're interested in the HTML shorthand style, the [Pug template language](/docs/languages/pug/) is likely a better option for new projects because it is more actively maintained and adopted.
+
 {% tableofcontents "open" %}
 
 | Eleventy Short Name | File Extension | npm Package                                |

--- a/src/docs/languages/handlebars.md
+++ b/src/docs/languages/handlebars.md
@@ -11,6 +11,8 @@ tags:
 layout: layouts/langs.njk
 ---
 
+[Handlebars](https://handlebarsjs.com/) is a template language that emphasizes simplicity and speed. As the name suggests, it's inspired by and a superset of the [Mustache](/docs/languages/mustache/) template language. It adds [several features](https://github.com/handlebars-lang/handlebars.js#differences-between-handlebarsjs-and-mustache) that Mustache doesn't have, like nested paths: you can refer to `{% raw %}{{variable.member}}{% endraw %}` in Handlebars, but not in Mustache.
+
 {% tableofcontents "open" %}
 
 | Eleventy Short Name | File Extension | npm Package                                                |

--- a/src/docs/languages/mdx.md
+++ b/src/docs/languages/mdx.md
@@ -7,6 +7,8 @@ relatedTitle: Template Language—MDX
 layout: layouts/langs.njk
 ---
 
+[MDX](https://mdxjs.com/) is an extension of [Markdown](/docs/languages/markdown/) that adds JavaScript support and embedded components using [JSX syntax](/docs/languages/jsx/). It can be a powerful language for writing content if you intend to include interactive components or intermix text with elements.
+
 <!-- {% tableofcontents "open" %} -->
 
 | Eleventy Short Name | File Extension | npm Package |
@@ -15,6 +17,7 @@ layout: layouts/langs.njk
 
 * Related languages: [Markdown](/docs/languages/markdown/), [JSX](/docs/languages/jsx/), [Custom](/docs/languages/custom/)
 * While [Markdown files](/docs/languages/markdown/) are preprocessed as Liquid, MDX files are not preprocessed by any other template syntax.
+* The Markdown in MDX files is parsed and transformed using [Remark](https://remark.js.org/), which is different from Eleventy's default Markdown parser, [markdown-it](https://github.com/markdown-it/markdown-it). Changes to Markdown options won't affect MDX, and output can be different from the same Markdown input.
 
 {% callout "info", "md" %}MDX requires ESM. This means your project `package.json` must contain `"type": "module"` or your configuration file must use the `.mjs` file extension, e.g. `eleventy.config.mjs`.{% endcallout %}
 

--- a/src/docs/languages/pug.md
+++ b/src/docs/languages/pug.md
@@ -7,13 +7,14 @@ eleventyNavigation:
 layout: layouts/langs.njk
 ---
 
+[Pug templates](https://pugjs.org/api/getting-started.html) let you write HTML pages in a terse shorthand.
+Previously these were known as Jade templates (the project was renamed).
+
 {% tableofcontents "open" %}
 
 | Eleventy Short Name | File Extension | npm Package                           |
 | ------------------- | -------------- | ------------------------------------- |
 | `pug`               | `.pug`         | [`pug`](https://github.com/pugjs/pug) |
-
-Pug templates were previously known as Jade templates (the project was renamed).
 
 | Eleventy or Plugin version | `pug` version |
 | --- | --- |


### PR DESCRIPTION
- Refs #1899

This adds descriptions to a batch of template languages:

- EJS
- Pug
- HAML (with a note that Pug is probably better for new projects)
- Mustache
- Handlebars
- MDX