### PR TITLE
Fix Cyber Banana starter name and add JuicyDocs starter

### DIFF
--- a/src/_data/starters/freshjuice-cyber-banana.json
+++ b/src/_data/starters/freshjuice-cyber-banana.json
@@ -1,6 +1,6 @@
 {
 	"url": "https://github.com/freshjuice-dev/cyber-banana-11ty-starter",
-	"name": "Berry Blast",
+	"name": "Cyber Banana",
 	"description": "A cyberpunk-themed developer portfolio starter with 11ty, Tailwind CSS, and vanilla JavaScript.",
 	"author": "freshjuice-dev",
 	"demo": "https://cyber-banana-starter.freshjuice.dev/"

--- a/src/_data/starters/freshjuice-juicydocs.json
+++ b/src/_data/starters/freshjuice-juicydocs.json
@@ -1,0 +1,7 @@
+{
+	"url": "https://github.com/freshjuice-dev/juicydocs-11ty-starter",
+	"name": "JuicyDocs",
+	"description": "A modern, fast, and accessible documentation starter template built with Eleventy and Tailwind CSS.",
+	"author": "freshjuice-dev",
+	"demo": "https://juicydocs.freshjuice.dev/"
+}


### PR DESCRIPTION
## Summary
- Fix copy-paste typo in Cyber Banana starter: renamed "Berry Blast" to "Cyber Banana"
- Add [JuicyDocs](https://github.com/freshjuice-dev/juicydocs-11ty-starter) — a modern, fast, and accessible documentation starter template built with Eleventy and Tailwind CSS

## Demo
- Cyber Banana: https://cyber-banana-starter.freshjuice.dev/
- JuicyDocs: https://juicydocs.freshjuice.dev/