### PR TITLE
Move template navigation to bottom of template pages

### DIFF
--- a/src/_includes/layouts/docs.njk
+++ b/src/_includes/layouts/docs.njk
@@ -23,10 +23,23 @@ isDocs: true
 {% if eleventyNavigation and eleventyNavigation.key %}
 {%- set navKey = eleventyNavigation.parent or eleventyNavigation.key -%}
 {%- set otherPages = navKey | navFiltered -%}
-{% if navKey != "Eleventy Documentation" and navKey != "Ecosystem" and otherPages.length > 1 %}
+{%- set breadcrumbs = eleventyNavigation.key | navBreadcrumbs -%}
+{%- set isTemplateLang = false -%}
+{%- for crumb in breadcrumbs -%}
+  {%- if crumb.key == "Template Languages" -%}{%- set isTemplateLang = true -%}{%- endif -%}
+{%- endfor -%}
+{% if otherPages.length > 1 or isTemplateLang %}
+{% if isTemplateLang %}
+<hr>
+<div class="elv-langlist" data-pagefind-ignore>
+	<span class="elv-langlist-hed">Template Languages:</span>
+{% templatelangs templatetypes, page %}
+</div>
+{% elseif navKey != "Eleventy Documentation" and navKey != "Ecosystem" %}
 <hr>
 <h3 data-ha-exclude>{% if eleventyNavigation.parent %}Other pages in {% endif %}<em>{{ navKey }}</em></h3>
 {{ otherPages | eleventyNavigationToHtml({ activeKey: eleventyNavigation.key, listClass: 'inlinelist inlinelist-no-nest', listItemClass: 'inlinelist-item', activeListItemClass: 'elv-cat-list-active' }) | safe }}
+{% endif %}
 {% endif %}
 {% endif %}
 

--- a/src/_includes/layouts/langs.njk
+++ b/src/_includes/layouts/langs.njk
@@ -30,11 +30,6 @@ layout: layouts/docs.njk
 
 <h1>{{ eleventyNavigation.key }}{% if addedInVersion %}{% addedin addedInVersion%}{% endif %}</h1>
 
-<div class="elv-langlist" data-pagefind-ignore>
-	<span class="elv-langlist-hed">Template Languages:</span>
-{% templatelangs templatetypes, page %}
-</div>
-
 {% if logoImage %}
 <p><img src="{{ logoImage }}" alt="Logo for {{ eleventyNavigation.key }}" eleventy:widths="200,400" class="elv-langlist-logo" sizes="200px"></p>
 {% endif %}


### PR DESCRIPTION
This navigation was good in that it shows nice custom data for template pages (the file format, inline with the link), but it had two big issues:

- It was at the very top of the documentation, stealing critical attention where we should be spending time explaining a template language rather than linking to other template languages.
- These pages _also_ had the default navigation links at the bottom that were a near-exact copy of the template-specific navigation links. This was just redundant and wasted space.

This updates the default template to use the template-specific style when in the templates area. I think that if the left navigation is improved (becomes sticky and focuses more intensely on the currently-viewed page), we could drop this kind of navigation entirely. But in the interest of keeping things simple and incremental, I think this is a good movement toward #1898.

Before:

<img width="2700" height="8863" alt="CleanShot 2026-02-08 at 11 53 10@2x" src="https://github.com/user-attachments/assets/459e2112-3e55-4474-b98f-38247fbaabb1" />

After:

<img width="2700" height="8591" alt="CleanShot 2026-02-08 at 11 52 43@2x" src="https://github.com/user-attachments/assets/3ac8c802-a700-414b-9376-13f55704c02d" />
