### PR TITLE
Support array values in findBy filter for multiple authors

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -201,6 +201,14 @@ function findBy(data, path, value) {
 			return false;
 		}
 
+		if (Array.isArray(gotten)) {
+			if (typeof value === "string") {
+				let valueLower = value.toLowerCase();
+				return gotten.some((item) => typeof item === "string" && item.toLowerCase() === valueLower);
+			}
+			return gotten.includes(value);
+		}
+
 		if (typeof value === "string") {
 			let valueLower = value.toLowerCase();
 			let dataLower = gotten.toLowerCase();

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -203,19 +203,13 @@ function findBy(data, path, value) {
 
 		if (Array.isArray(gotten)) {
 			if (typeof value === "string") {
-				let valueLower = value.toLowerCase();
-				return gotten.some((item) => typeof item === "string" && item.toLowerCase() === valueLower);
+				return gotten.some((item) => typeof item === "string" && item.localeCompare(value, undefined, { sensitivity: "base" }) === 0);
 			}
 			return gotten.includes(value);
 		}
 
 		if (typeof value === "string") {
-			let valueLower = value.toLowerCase();
-			let dataLower = gotten.toLowerCase();
-			if (valueLower === dataLower) {
-				return true;
-			}
-			return false;
+			return gotten.localeCompare(value, undefined, {sensitivity: "base"}) === 0;
 		}
 
 		return value === gotten;

--- a/src/_data/starters/freshjuice-11ty-starter.json
+++ b/src/_data/starters/freshjuice-11ty-starter.json
@@ -2,6 +2,6 @@
 	"url": "https://github.com/freshjuice-dev/freshjuice-11ty-starter",
 	"name": "Snappy Lemon",
 	"description": "Modern 11ty v3 starter with TailwindCSS v4, Alpine.js, CloudCannon CMS integration, Bookshop visual editing, Pagefind search, and accessibility-first design",
-	"author": "freshjuice-dev",
+	"author": ["freshjuice-dev", "reatlat"],
 	"demo": "https://snappy-lemon-starter.freshjuice.dev/"
 }

--- a/src/_data/starters/freshjuice-berry-blast.json
+++ b/src/_data/starters/freshjuice-berry-blast.json
@@ -2,6 +2,6 @@
 	"url": "https://github.com/freshjuice-dev/berry-blast-11ty-starter",
 	"name": "Berry Blast",
 	"description": "Modern 11ty v3 starter with TailwindCSS v4, Alpine.js, Pagefind search, Phosphor Icons, Shiki syntax highlighting, and WCAG 2.1 AA accessibility",
-	"author": "freshjuice-dev",
+	"author": ["freshjuice-dev", "reatlat"],
 	"demo": "https://berry-blast-starter.freshjuice.dev/"
 }

--- a/src/_data/starters/freshjuice-cyber-banana.json
+++ b/src/_data/starters/freshjuice-cyber-banana.json
@@ -2,6 +2,6 @@
 	"url": "https://github.com/freshjuice-dev/cyber-banana-11ty-starter",
 	"name": "Berry Blast",
 	"description": "A cyberpunk-themed developer portfolio starter with 11ty, Tailwind CSS, and vanilla JavaScript.",
-	"author": "freshjuice-dev",
+	"author": ["freshjuice-dev", "reatlat"],
 	"demo": "https://cyber-banana-starter.freshjuice.dev/"
 }

--- a/src/_data/starters/freshjuice-electric-lime.json
+++ b/src/_data/starters/freshjuice-electric-lime.json
@@ -2,6 +2,6 @@
 	"url": "https://github.com/freshjuice-dev/electric-lime-11ty-starter",
 	"name": "Electric Lime",
 	"description": "Vibrant 11ty v3 starter with TailwindCSS v4, Alpine.js, Pagefind search, Shiki syntax highlighting, image optimization, and WCAG 2.1 AA accessibility",
-	"author": "freshjuice-dev",
+	"author": ["freshjuice-dev", "reatlat"],
 	"demo": "https://electric-lime-starter.freshjuice.dev/"
 }


### PR DESCRIPTION
## Summary
- Enhance the `findBy` filter in `eleventy.config.js` to support array values, enabling fields like `author` to list multiple authors
- Update FreshJuice starters to use `["freshjuice-dev", "reatlat"]` as a real-world use case

## Problem
Currently, starters (and plugins) can only have a single `author` string. This means a project with multiple contributors can only appear on one author's page.

## Solution
Add an `Array.isArray()` check to the `findBy` function so that when a field value is an array, it matches if **any** element in the array equals the search value. This is fully backward-compatible — existing string values continue to work unchanged.

```js
// Before (string only)
"author": "freshjuice-dev"

// After (string or array)
"author": ["freshjuice-dev", "reatlat"]
```

## Test plan
- [x] Verified locally that array-based authors render correctly on both author pages
- [x] Confirmed existing single-string authors are unaffected
- [x] Case-insensitive matching works for array elements