### PR TITLE
Make it clear about which Collections API are sorted

### DIFF
--- a/src/docs/collections-api.md
+++ b/src/docs/collections-api.md
@@ -15,8 +15,8 @@ Inside of your `eleventy.config.js` config file, you can use the `addCollection`
 export default function (eleventyConfig) {
 	// async-friendly
 	eleventyConfig.addCollection("myCollectionName", async (collectionsApi) => {
-		// get unsorted items
-		return collectionsApi.getAll();
+		// get items
+		return collectionsApi.getAllSorted();
 	});
 };
 {% endset %}
@@ -30,9 +30,54 @@ export default function (eleventyConfig) {
 
 The data collection gets passed to the callback. You can use it in all sorts of ways:
 
+### getAllSorted()
+
+Returns an array of items sorted by the [default sorting algorithm](/docs/collections/#sorting), just like they'd be sorted in a template.
+
+{% set codeContent %}
+export default function (eleventyConfig) {
+	// Use the default sorting algorithm (ascending by date, filename tiebreaker)
+	eleventyConfig.addCollection("allMySortedContent", function (collectionsApi) {
+		return collectionsApi.getAllSorted();
+	});
+};
+{% endset %}
+{% include "snippets/configDefinition.njk" %}
+
+#### Example: `getAllSorted().reverse()`
+
+{% set codeContent %}
+export default function (eleventyConfig) {
+	// Use the default sorting algorithm in reverse (descending dir, date, filename)
+	// Note that using a template engine’s `reverse` filter might be easier here
+	eleventyConfig.addCollection("myPostsReverse", function (collectionsApi) {
+		return collectionsApi.getAllSorted().reverse();
+	});
+};
+{% endset %}
+{% include "snippets/configDefinition.njk" %}
+
+Note that while Array `.reverse()` mutates the array _in-place_, all Eleventy Collection API methods return new copies of collection arrays and can be modified without side effects to other collections. You can also use `.toReversed()` if you want to avoid mutations (Node 20+). However, <a href="/docs/collections.md#do-not-use-array-reverse()">you do need to <strong>be careful when using Array `.reverse()`</strong> in templates!</a>
+
+#### Example: `getAllSorted().filter()`
+
+{% set codeContent %}
+export default function (eleventyConfig) {
+	// Filter using `Array.filter`
+	eleventyConfig.addCollection("onlyMarkdown", function (collectionsApi) {
+		return collectionsApi.getAllSorted().filter(function (item) {
+			// Only return content that was originally a markdown file
+			let extension = item.inputPath.split(".").pop();
+			return extension === "md";
+		});
+	});
+};
+{% endset %}
+{% include "snippets/configDefinition.njk" %}
+
 ### getAll()
 
-Returns an array.
+Returns an array of items in arbitrary order. This is marginally faster than `getAllSorted()` if you don't need a particular ordering, but most of the time you'll want `getAllSorted` instead.
 
 {% set codeContent %}
 export default function (eleventyConfig) {
@@ -80,54 +125,10 @@ Curious where the date is coming from? [Read more about Content Dates](/docs/dat
 
 Note that the last example adding the `myCustomSort` collection will be available in your templates as `collections.myCustomSort`.
 
-### getAllSorted()
-
-Returns an array.
-
-{% set codeContent %}
-export default function (eleventyConfig) {
-	// Use the default sorting algorithm (ascending by date, filename tiebreaker)
-	eleventyConfig.addCollection("allMySortedContent", function (collectionsApi) {
-		return collectionsApi.getAllSorted();
-	});
-};
-{% endset %}
-{% include "snippets/configDefinition.njk" %}
-
-#### Example: `getAllSorted().reverse()`
-
-{% set codeContent %}
-export default function (eleventyConfig) {
-	// Use the default sorting algorithm in reverse (descending dir, date, filename)
-	// Note that using a template engine’s `reverse` filter might be easier here
-	eleventyConfig.addCollection("myPostsReverse", function (collectionsApi) {
-		return collectionsApi.getAllSorted().reverse();
-	});
-};
-{% endset %}
-{% include "snippets/configDefinition.njk" %}
-
-Note that while Array `.reverse()` mutates the array _in-place_, all Eleventy Collection API methods return new copies of collection arrays and can be modified without side effects to other collections. You can also use `.toReversed()` if you want to avoid mutations (Node 20+). However, <a href="/docs/collections.md#do-not-use-array-reverse()">you do need to <strong>be careful when using Array `.reverse()`</strong> in templates!</a>
-
-#### Example: `getAllSorted().filter()`
-
-{% set codeContent %}
-export default function (eleventyConfig) {
-	// Filter using `Array.filter`
-	eleventyConfig.addCollection("onlyMarkdown", function (collectionsApi) {
-		return collectionsApi.getAllSorted().filter(function (item) {
-			// Only return content that was originally a markdown file
-			let extension = item.inputPath.split(".").pop();
-			return extension === "md";
-		});
-	});
-};
-{% endset %}
-{% include "snippets/configDefinition.njk" %}
 
 ### getFilteredByTag( tagName )
 
-Returns an array.
+Returns a sorted array.
 
 {% set codeContent %}
 export default function (eleventyConfig) {
@@ -141,7 +142,7 @@ export default function (eleventyConfig) {
 
 ### getFilteredByTags( tagName, secondTagName, […] )
 
-Retrieve content that includes _all_ of the tags passed in. Returns an array.
+Retrieve content that includes _all_ of the tags passed in. Returns a sorted array.
 
 {% set codeContent %}
 export default function (eleventyConfig) {


### PR DESCRIPTION
- Fixes #980

This:

- Moves `getAll` below `getAllSorted` because it's much more likely that people want sorted results
- Makes it clear that other APIs provide sorted results
- Makes it clear that `getAll` does not sort results.