### PR TITLE
fix guide sidebar sticky positioning when expanded

### DIFF
--- a/src/_includes/components/toc.css
+++ b/src/_includes/components/toc.css
@@ -58,7 +58,7 @@
 	.elv-toc-c {
 		flex-grow: 1;
 	}
-	.elv-toc-list:has(a[href="/docs/projects/"] + details:not([open])) {
+	.elv-toc-list:has(a[href="/docs/projects/"] + details) {
 		position: sticky;
 		top: var(--elv-toc-sticky-top);
 	}


### PR DESCRIPTION
Fixes #1788

Sticky position for sidebar was only working when the Guide tab was not opened - this fixes it : )

On a side note, the sidebar is now ridiculously long if everything is expanded. Guide in particular is a really long section. I might raise this as an issue if this is approved. 