### PR TITLE
docs: use collectionsApi variable name consistently

### DIFF
--- a/src/docs/collections-api.md
+++ b/src/docs/collections-api.md
@@ -171,8 +171,8 @@ Returns an array. Will match an arbitrary glob (or an array of globs) against th
 
 {% set codeContent %}
 export default function (eleventyConfig) {
-	eleventyConfig.addCollection("onlyMarkdown", function (collectionApi) {
-		return collectionApi.getFilteredByGlob("**/*.md");
+	eleventyConfig.addCollection("onlyMarkdown", function (collectionsApi) {
+		return collectionsApi.getFilteredByGlob("**/*.md");
 	});
 
 	eleventyConfig.addCollection("posts", function (collectionApi) {


### PR DESCRIPTION
hello and thanks for maintaining this stellar tool! 👋 

this is just an anal-retentive tweak to align the variable name in a few more snippets with the name of the actual [Collections API](https://www.11ty.dev/docs/collections-api/). 😅 