### PR TITLE
Add DeployHQ to Jamstack Providers in deployment docs

### DIFF
--- a/src/docs/deployment.md
+++ b/src/docs/deployment.md
@@ -49,6 +49,10 @@ hosts:
   - name: CloudRay
     url: https://cloudray.io/articles/how-to-deploy-your-eleventy-website
     screenshotSize: medium
+  - name: DeployHQ
+    url: https://www.deployhq.com/
+    screenshotSize: medium
+    description: Git-based deployment platform that runs your Eleventy build on its servers and transfers the <code>_site/</code> output to your own server via SSH/SFTP/FTP (or to S3, Azure Blob, or Rackspace Cloud Files). Supports multiple environments with branch-to-server mapping, config-file injection, atomic releases, one-click rollback, and pre/post deploy hooks.
 classicHosts:
   - name: Vercel CLI
     url: https://vercel.com/cli


### PR DESCRIPTION
Adds DeployHQ to the Jamstack Providers list on the Deployment & Hosting page. DeployHQ is a Git-based deployment platform (GitHub/GitLab/Bitbucket) that runs your Eleventy build (`npx @11ty/eleventy`) on its build servers and transfers the resulting `_site/` directory to your own server over SSH/SFTP/FTP — or to S3, Azure Blob, or Rackspace Cloud Files. It supports multiple environments per project (e.g. staging vs production with branch-to-server mapping), config-file injection, atomic releases, one-click rollback, and pre/post deploy hooks. There's a free tier at https://www.deployhq.com/signup.

The change is a single YAML entry under the existing `hosts:` array in the frontmatter of `src/docs/deployment.md`. No narrative content or layout changes are needed — the page renders provider cards from frontmatter via `site-card.njk`. This gives Eleventy users who want to deploy to their own servers (rather than a managed Jamstack PaaS) a documented option alongside Render, Netlify, Cloudflare Pages, GitHub Pages, etc.
